### PR TITLE
feat(es256k): added optional feature to invert signature

### DIFF
--- a/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES256KVerifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES256KVerifier.swift
@@ -34,58 +34,17 @@ public struct ES256KVerifier: Verifier {
             guard ES256KVerifier.bouncyCastleFailSafe else {
                 return false
             }
-            let bcSignature = transcodeSignatureToDERBitcoin(derEncodedSig: signature)
-            return try publicKey.isValidSignature(getSignature(bcSignature), for: hash)
+            let bcSignature = try transcodeBCSignatureToBitcoin(signature: signature)
+            return publicKey.isValidSignature(bcSignature, for: hash)
         }
         return true
     }
     
     // This function helps transcode the signature from bouncy castle to bitcoin
-    private func transcodeSignatureToDERBitcoin(derEncodedSig: Data) -> Data {
-        // Helper to extract integer components from DER format
-        func extractInteger(from data: Data, at offset: inout Int) -> Data {
-            guard data[offset] == 0x02 else {
-                fatalError("Expected integer")
-            }
-            offset += 1 // Move past the 0x02
-            
-            let length = Int(data[offset])
-            offset += 1 // Move past the length byte
-            
-            let integerData = data[offset..<(offset + length)]
-            offset += length // Move past the integer data
-            return Data(integerData.reversed()) // Reverse the bytes
-        }
-        
-        var offset = 0
-        
-        // Verify initial DER sequence byte and length
-        guard derEncodedSig[offset] == 0x30 else {
-            fatalError("Invalid DER encoding")
-        }
-        offset += 1
-        
-        let _ = Int(derEncodedSig[offset]) // Total length (not used)
-        offset += 1
-        
-        // Extract and reverse R and S
-        let reversedR = extractInteger(from: derEncodedSig, at: &offset)
-        let reversedS = extractInteger(from: derEncodedSig, at: &offset)
-        
-        // Re-encode to DER format
-        var derEncoded = Data([0x30]) // Start of DER sequence
-        let totalLength = reversedR.count + reversedS.count + 4 // Total length of the content
-        derEncoded.append(contentsOf: [UInt8(totalLength)])
-        
-        // Append R
-        derEncoded.append(contentsOf: [0x02, UInt8(reversedR.count)])
-        derEncoded.append(reversedR)
-        
-        // Append S
-        derEncoded.append(contentsOf: [0x02, UInt8(reversedS.count)])
-        derEncoded.append(reversedS)
-        
-        return derEncoded
+    private func transcodeBCSignatureToBitcoin(signature: Data) throws -> secp256k1.Signing.ECDSASignature {
+        let signature = try getSignature(signature)
+        let signatureInvertedRS = invertR_S(signatureData: signature.dataRepresentation)
+        return try .init(dataRepresentation: signatureInvertedRS)
     }
 }
 

--- a/Tests/JWATests/ES256KTests.swift
+++ b/Tests/JWATests/ES256KTests.swift
@@ -102,4 +102,58 @@ final class Secp256k1Tests: XCTestCase {
             key: key.jwkRepresentation
         ))
     }
+    
+    func testSecp256k1CycleInvertedRS() throws {
+        let payload = "Test".data(using: .utf8)!
+        let key = try secp256k1.Signing.PrivateKey(format: .uncompressed)
+        ES256KSigner.invertedBytesR_S = true
+        
+        let signature = try ES256KSigner().sign(data: payload, key: key.jwkRepresentation)
+        
+        ES256KVerifier.bouncyCastleFailSafe = true
+        
+        XCTAssertTrue(try ES256KVerifier().verify(
+            data: payload,
+            signature: signature,
+            key: key.jwkRepresentation
+        ))
+    }
+    
+    func testSecp256k1SignatureFromJSLibrary() throws {
+        let payload = try "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6cHJpc206MGYzN2Y2YmRmZWNlMzQzNzJmMzE3YmM5NDQyNzY5YzI0Yzk1ZmNkYjQzZDAzOTNiOTZiOGQ3YWEwODBlZDBiNzpDcmtCQ3JZQkVqb0tCbUYxZEdndE1SQUVTaTRLQ1hObFkzQXlOVFpyTVJJaEF2TWkxYUZZaTdOUlFWQ00zU2s2TjBvQkhIOXlabUhUcGtOT0tyd1QzYWdVRWpzS0IybHpjM1ZsTFRFUUFrb3VDZ2x6WldOd01qVTJhekVTSVFLSkp2UkloYjZLWG9iTnhWQnhaS2ZyMkdCcnNsc0lUb1doSVFCUDEyMS1yaEk3Q2dkdFlYTjBaWEl3RUFGS0xnb0pjMlZqY0RJMU5tc3hFaUVDRXI2QkJMbFVEcjFMcHdJZ1JLcHZZQ1BYUkRfWFh5SFpTbWdVTXMxZlpVMCIsInN1YiI6ImRpZDpwcmlzbTpjNzVlYjA4ZmQ2ZjUyOTcxNmUxYzBhZWZhNmQ2NDBkNDgyNTk2ODFjMjk5ZTMyMDNiYWUzZGRmMjMzNjU3MzY3OkN0OEJDdHdCRW5RS0gyRjFkR2hsYm5ScFkyRjBhVzl1WVhWMGFHVnVkR2xqWVhScGIyNUxaWGtRQkVKUENnbHpaV053TWpVMmF6RVNJSnFKNWNSZmhqMUpybXlxVjlFcWNEdTBWdGRGR1VmV2VxRVB4cEtvWEFsa0dpQ3NLY1lmTVZPX1dlM1l1TlBmZzB5VUlrUHdaYU81TmpWYWl3OTFpcUs0Y2hKa0NnOXRZWE4wWlhKdFlYTjBaWEpMWlhrUUFVSlBDZ2x6WldOd01qVTJhekVTSUpxSjVjUmZoajFKcm15cVY5RXFjRHUwVnRkRkdVZldlcUVQeHBLb1hBbGtHaUNzS2NZZk1WT19XZTNZdU5QZmcweVVJa1B3WmFPNU5qVmFpdzkxaXFLNGNnIiwibmJmIjoxNzEzNzg4OTA0LCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJlbWFpbEFkZHJlc3MiOiJjb3Jwb3JhdGVAZG9tYWluLmNvbSIsImRyaXZpbmdDbGFzcyI6MSwiZHJpdmluZ0xpY2Vuc2VJRCI6IkVTLTEyMzQ1Njc4OTAiLCJpZCI6ImRpZDpwcmlzbTpjNzVlYjA4ZmQ2ZjUyOTcxNmUxYzBhZWZhNmQ2NDBkNDgyNTk2ODFjMjk5ZTMyMDNiYWUzZGRmMjMzNjU3MzY3OkN0OEJDdHdCRW5RS0gyRjFkR2hsYm5ScFkyRjBhVzl1WVhWMGFHVnVkR2xqWVhScGIyNUxaWGtRQkVKUENnbHpaV053TWpVMmF6RVNJSnFKNWNSZmhqMUpybXlxVjlFcWNEdTBWdGRGR1VmV2VxRVB4cEtvWEFsa0dpQ3NLY1lmTVZPX1dlM1l1TlBmZzB5VUlrUHdaYU81TmpWYWl3OTFpcUs0Y2hKa0NnOXRZWE4wWlhKdFlYTjBaWEpMWlhrUUFVSlBDZ2x6WldOd01qVTJhekVTSUpxSjVjUmZoajFKcm15cVY5RXFjRHUwVnRkRkdVZldlcUVQeHBLb1hBbGtHaUNzS2NZZk1WT19XZTNZdU5QZmcweVVJa1B3WmFPNU5qVmFpdzkxaXFLNGNnIiwiZGF0ZU9mSXNzdWFuY2UiOiIyMDIzLTAxLTAxVDAyOjAyOjAyWiJ9LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOlwvXC93d3cudzMub3JnXC8yMDE4XC9jcmVkZW50aWFsc1wvdjEiXSwiY3JlZGVudGlhbFN0YXR1cyI6eyJzdGF0dXNQdXJwb3NlIjoiUmV2b2NhdGlvbiIsInN0YXR1c0xpc3RJbmRleCI6MywiaWQiOiJodHRwOlwvXC8xOTIuMTY4LjEuNDQ6ODAwMFwvcHJpc20tYWdlbnRcL2NyZWRlbnRpYWwtc3RhdHVzXC9jMDkxOGViNi1lZGIzLTRjMTUtYWM4OS0yZDk5MTZmMjFmYjUjMyIsInR5cGUiOiJTdGF0dXNMaXN0MjAyMUVudHJ5Iiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwOlwvXC8xOTIuMTY4LjEuNDQ6ODAwMFwvcHJpc20tYWdlbnRcL2NyZWRlbnRpYWwtc3RhdHVzXC9jMDkxOGViNi1lZGIzLTRjMTUtYWM4OS0yZDk5MTZmMjFmYjUifX19".tryToData()
+        
+        let publicKeyX = try Base64URL.decode("iSb0SIW-il6GzcVQcWSn69hga7JbCE6FoSEAT9dtfq4")
+        let publicKeyY = try Base64URL.decode("9FcLWxguRJYRCVcuN7AHDo8wePDUVDI9UrvMSaKXbiw")
+        let publicKeyRaw = [0x04] + publicKeyX + publicKeyY
+        let publicKey = try secp256k1.Signing.PublicKey(dataRepresentation: publicKeyRaw, format: .uncompressed)
+        let sigantureBase64 = "uijHd6DMBrfDq_-K2fhB17Tm4eI4twLFMu18Lz_xpfF1K3yuJ58CkUqKAb_HNORrP9e4jc8BTbqGwDzk7utB9A"
+        let signatureRaw = try Base64URL.decode(sigantureBase64)
+        
+        ES256KVerifier.bouncyCastleFailSafe = true
+        
+        XCTAssertTrue(try ES256KVerifier().verify(
+            data: payload,
+            signature: signatureRaw,
+            key: publicKey.jwkRepresentation
+        ))
+    }
+    
+    func testSecp256k1JSLibrarySignatureVerifyFailIfFeatureNotActive() throws {
+        let payload = try "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6cHJpc206MGYzN2Y2YmRmZWNlMzQzNzJmMzE3YmM5NDQyNzY5YzI0Yzk1ZmNkYjQzZDAzOTNiOTZiOGQ3YWEwODBlZDBiNzpDcmtCQ3JZQkVqb0tCbUYxZEdndE1SQUVTaTRLQ1hObFkzQXlOVFpyTVJJaEF2TWkxYUZZaTdOUlFWQ00zU2s2TjBvQkhIOXlabUhUcGtOT0tyd1QzYWdVRWpzS0IybHpjM1ZsTFRFUUFrb3VDZ2x6WldOd01qVTJhekVTSVFLSkp2UkloYjZLWG9iTnhWQnhaS2ZyMkdCcnNsc0lUb1doSVFCUDEyMS1yaEk3Q2dkdFlYTjBaWEl3RUFGS0xnb0pjMlZqY0RJMU5tc3hFaUVDRXI2QkJMbFVEcjFMcHdJZ1JLcHZZQ1BYUkRfWFh5SFpTbWdVTXMxZlpVMCIsInN1YiI6ImRpZDpwcmlzbTpjNzVlYjA4ZmQ2ZjUyOTcxNmUxYzBhZWZhNmQ2NDBkNDgyNTk2ODFjMjk5ZTMyMDNiYWUzZGRmMjMzNjU3MzY3OkN0OEJDdHdCRW5RS0gyRjFkR2hsYm5ScFkyRjBhVzl1WVhWMGFHVnVkR2xqWVhScGIyNUxaWGtRQkVKUENnbHpaV053TWpVMmF6RVNJSnFKNWNSZmhqMUpybXlxVjlFcWNEdTBWdGRGR1VmV2VxRVB4cEtvWEFsa0dpQ3NLY1lmTVZPX1dlM1l1TlBmZzB5VUlrUHdaYU81TmpWYWl3OTFpcUs0Y2hKa0NnOXRZWE4wWlhKdFlYTjBaWEpMWlhrUUFVSlBDZ2x6WldOd01qVTJhekVTSUpxSjVjUmZoajFKcm15cVY5RXFjRHUwVnRkRkdVZldlcUVQeHBLb1hBbGtHaUNzS2NZZk1WT19XZTNZdU5QZmcweVVJa1B3WmFPNU5qVmFpdzkxaXFLNGNnIiwibmJmIjoxNzEzNzg4OTA0LCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJlbWFpbEFkZHJlc3MiOiJjb3Jwb3JhdGVAZG9tYWluLmNvbSIsImRyaXZpbmdDbGFzcyI6MSwiZHJpdmluZ0xpY2Vuc2VJRCI6IkVTLTEyMzQ1Njc4OTAiLCJpZCI6ImRpZDpwcmlzbTpjNzVlYjA4ZmQ2ZjUyOTcxNmUxYzBhZWZhNmQ2NDBkNDgyNTk2ODFjMjk5ZTMyMDNiYWUzZGRmMjMzNjU3MzY3OkN0OEJDdHdCRW5RS0gyRjFkR2hsYm5ScFkyRjBhVzl1WVhWMGFHVnVkR2xqWVhScGIyNUxaWGtRQkVKUENnbHpaV053TWpVMmF6RVNJSnFKNWNSZmhqMUpybXlxVjlFcWNEdTBWdGRGR1VmV2VxRVB4cEtvWEFsa0dpQ3NLY1lmTVZPX1dlM1l1TlBmZzB5VUlrUHdaYU81TmpWYWl3OTFpcUs0Y2hKa0NnOXRZWE4wWlhKdFlYTjBaWEpMWlhrUUFVSlBDZ2x6WldOd01qVTJhekVTSUpxSjVjUmZoajFKcm15cVY5RXFjRHUwVnRkRkdVZldlcUVQeHBLb1hBbGtHaUNzS2NZZk1WT19XZTNZdU5QZmcweVVJa1B3WmFPNU5qVmFpdzkxaXFLNGNnIiwiZGF0ZU9mSXNzdWFuY2UiOiIyMDIzLTAxLTAxVDAyOjAyOjAyWiJ9LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOlwvXC93d3cudzMub3JnXC8yMDE4XC9jcmVkZW50aWFsc1wvdjEiXSwiY3JlZGVudGlhbFN0YXR1cyI6eyJzdGF0dXNQdXJwb3NlIjoiUmV2b2NhdGlvbiIsInN0YXR1c0xpc3RJbmRleCI6MywiaWQiOiJodHRwOlwvXC8xOTIuMTY4LjEuNDQ6ODAwMFwvcHJpc20tYWdlbnRcL2NyZWRlbnRpYWwtc3RhdHVzXC9jMDkxOGViNi1lZGIzLTRjMTUtYWM4OS0yZDk5MTZmMjFmYjUjMyIsInR5cGUiOiJTdGF0dXNMaXN0MjAyMUVudHJ5Iiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwOlwvXC8xOTIuMTY4LjEuNDQ6ODAwMFwvcHJpc20tYWdlbnRcL2NyZWRlbnRpYWwtc3RhdHVzXC9jMDkxOGViNi1lZGIzLTRjMTUtYWM4OS0yZDk5MTZmMjFmYjUifX19".tryToData()
+        
+        let publicKeyX = try Base64URL.decode("iSb0SIW-il6GzcVQcWSn69hga7JbCE6FoSEAT9dtfq4")
+        let publicKeyY = try Base64URL.decode("9FcLWxguRJYRCVcuN7AHDo8wePDUVDI9UrvMSaKXbiw")
+        let publicKeyRaw = [0x04] + publicKeyX + publicKeyY
+        let publicKey = try secp256k1.Signing.PublicKey(dataRepresentation: publicKeyRaw, format: .uncompressed)
+        let sigantureBase64 = "uijHd6DMBrfDq_-K2fhB17Tm4eI4twLFMu18Lz_xpfF1K3yuJ58CkUqKAb_HNORrP9e4jc8BTbqGwDzk7utB9A"
+        let signatureRaw = try Base64URL.decode(sigantureBase64)
+        
+        ES256KVerifier.bouncyCastleFailSafe = false
+        
+        XCTAssertFalse(try ES256KVerifier().verify(
+            data: payload,
+            signature: signatureRaw,
+            key: publicKey.jwkRepresentation
+        ))
+    }
 }


### PR DESCRIPTION
Since most of other jwt libraries in other languages have the R and S bytes reversed.

This has 2 optional features:
First you can enable inverted RS signature from ES256KSigner.invertedBytesR_S = true, this will reverse R bytes, reverse S bytes and concatenate both, this will enable the signatures to be verified by other libraries

Second you can enable ES256KVerifier.bouncyCastleFailSafe = true this will failsafe to reversing the bytes if the first verification fails. Providing verification for both case scenarios.