### PR TITLE
feat(jwt): add dsl claims builder

### DIFF
--- a/Sources/JSONWebToken/Claims/ArrayClaim.swift
+++ b/Sources/JSONWebToken/Claims/ArrayClaim.swift
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents an array claim within a JWT.
+public struct ArrayClaim: Claim {
+    public var value: ClaimElement
+    
+    /// A result builder for constructing array claims.
+    @resultBuilder
+    public struct ArrayClaimBuilder {
+        /// Builds an array of `ArrayElementClaim` from the provided components.
+        /// - Parameter components: The array element claims to include in the array.
+        /// - Returns: An array of `ArrayElementClaim`.
+        public static func buildBlock(_ components: ArrayElementClaim...) -> [ArrayElementClaim] {
+            components
+        }
+        
+        /// Builds an array of `ArrayElementClaim` from the provided components.
+        /// - Parameter components: The array element claims to include in the array.
+        /// - Returns: An array of `ArrayElementClaim`.
+        public static func buildBlock(_ components: Claim...) -> [Claim] {
+            components
+        }
+        
+        /// Builds an array of `StringClaim` from the provided components.
+        /// - Parameter components: The string claims to include in the array.
+        /// - Returns: An array of `StringClaim`.
+        public static func buildBlock(_ components: StringClaim...) -> [StringClaim] {
+            components
+        }
+    }
+    
+    /// Initializes an `ArrayClaim` with a key and a builder for the array elements.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - claims: A closure that returns an array of `ArrayElementClaim` using the result builder.
+    public init(key: String, @ArrayClaimBuilder claims: () -> [ArrayElementClaim]) {
+        self.value = .init(key: key, element: .array(claims().map(\.value)))
+    }
+    
+    /// Initializes an `ArrayClaim` with a key and a builder for the array elements.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - claims: A closure that returns an array of `Claim` using the result builder.
+    public init(key: String, @ArrayClaimBuilder claims: () -> [Claim]) {
+        self.value = .init(key: key, element: .array(claims().map(\.value)))
+    }
+}
+
+/// Represents an element within an array claim.
+public struct ArrayElementClaim {
+    let value: ClaimElement
+    
+    /// Creates an `ArrayElementClaim` with a string value.
+    /// - Parameter str: The string value for the claim.
+    /// - Returns: An `ArrayElementClaim` containing the string value.
+    public static func string(_ str: String) -> ArrayElementClaim {
+        .init(value: StringClaim(key: "", value: str).value)
+    }
+    
+    /// Creates an `ArrayElementClaim` with a numeric value.
+    /// - Parameter number: The numeric value for the claim.
+    /// - Returns: An `ArrayElementClaim` containing the numeric value.
+    public static func number<N: Numeric & Codable>(_ number: N) -> ArrayElementClaim {
+        .init(value: NumberClaim(key: "", value: number).value)
+    }
+    
+    /// Creates an `ArrayElementClaim` with a boolean value.
+    /// - Parameter boolean: The boolean value for the claim.
+    /// - Returns: An `ArrayElementClaim` containing the boolean value.
+    public static func bool(_ boolean: Bool) -> ArrayElementClaim {
+        .init(value: BoolClaim(key: "", value: boolean).value)
+    }
+    
+    /// Creates an `ArrayElementClaim` with an array of claims.
+    /// - Parameter claims: A closure that returns an array of `ArrayElementClaim` using the result builder.
+    /// - Returns: An `ArrayElementClaim` containing the array of claims.
+    public static func array(@ArrayClaim.ArrayClaimBuilder claims: () -> [ArrayElementClaim]) -> ArrayElementClaim {
+        .init(value: ArrayClaim(key: "", claims: claims).value)
+    }
+    
+    /// Creates an `ArrayElementClaim` with an object of claims.
+    /// - Parameter claims: A closure that returns an array of `Claim` using the result builder.
+    /// - Returns: An `ArrayElementClaim` containing the object of claims.
+    public static func object(@ObjectClaim.ObjectClaimBuilder claims: () -> [Claim]) -> ArrayElementClaim {
+        .init(value: ObjectClaim(key: "", claims: claims).value)
+    }
+}

--- a/Sources/JSONWebToken/Claims/AudienceClaim.swift
+++ b/Sources/JSONWebToken/Claims/AudienceClaim.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `AudienceClaim`.
+typealias AudClaim = AudienceClaim
+
+/// Represents the "aud" (audience) claim in a JWT.
+public struct AudienceClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes an `AudienceClaim` with a string value.
+    /// - Parameter value: The audience value for the claim.
+    public init(value: String) {
+        self.value = ClaimElement(key: "aud", element: .codable(value))
+    }
+    
+    /// Initializes an `AudienceClaim` with an array of audience values using a result builder.
+    /// - Parameter claims: A closure that returns an array of `StringClaim` using the result builder.
+    init(@ArrayClaim.ArrayClaimBuilder claims: () -> [StringClaim]) {
+        self.value = .init(key: "aud", element: .array(claims().map(\.value)))
+    }
+}

--- a/Sources/JSONWebToken/Claims/BoolClaim.swift
+++ b/Sources/JSONWebToken/Claims/BoolClaim.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents a boolean claim within a JWT.
+public struct BoolClaim: Claim {
+    public var value: ClaimElement
+    
+    /// Initializes a `BoolClaim` with a key and a boolean value.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - value: The boolean value for the claim.
+    public init(key: String, value: Bool) {
+        self.value = ClaimElement(key: key, element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/Claims+Codable.swift
+++ b/Sources/JSONWebToken/Claims/Claims+Codable.swift
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+extension ClaimElement: Encodable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        switch element {
+        case .codable(let obj):
+            try container.encode(obj, forKey: .init(stringValue: key)!)
+        case .element(let element):
+            try container.encode(element, forKey: .init(stringValue: key)!)
+        case .array(let elements):
+            var nested = container.nestedUnkeyedContainer(forKey: .init(stringValue: key)!)
+            try encodeArrayElements(container: &nested, elements: elements)
+        case .object(let elements):
+            var nested: KeyedEncodingContainer<DynamicCodingKey>
+            if key.isEmpty {
+                nested = container
+            } else {
+                nested = container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: .init(stringValue: key)!)
+            }
+            
+            try encodeObjectElement(container: &nested, elements: elements)
+        }
+    }
+    
+    private func encodeArrayElements(container: inout UnkeyedEncodingContainer, elements: [ClaimElement]) throws {
+        try elements.forEach {
+            switch $0.element {
+            case .codable(let obj):
+                try container.encode(obj)
+            case .element(let element):
+                try container.encode(element)
+            case .array(let elements):
+                var nested = container.nestedUnkeyedContainer()
+                try encodeArrayElements(container: &nested, elements: elements)
+            case .object(let elements):
+                var nested = container.nestedContainer(keyedBy: DynamicCodingKey.self)
+                try encodeObjectElement(container: &nested, elements: elements)
+            }
+        }
+    }
+    
+    private func encodeObjectElement(container: inout KeyedEncodingContainer<DynamicCodingKey>, elements: [ClaimElement]) throws {
+        try elements.forEach {
+            switch $0.element {
+            case .codable(let obj):
+                try container.encode(obj, forKey: .init(stringValue: $0.key)!)
+            case .element(let element):
+                try container.encode(element, forKey: .init(stringValue: $0.key)!)
+            case .array(let elements):
+                var nested = container.nestedUnkeyedContainer(forKey: .init(stringValue: $0.key)!)
+                try encodeArrayElements(container: &nested, elements: elements)
+            case .object(let elements):
+                var nested = container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: .init(stringValue: $0.key)!)
+                try encodeObjectElement(container: &nested, elements: elements)
+            }
+        }
+    }
+}
+
+struct DynamicCodingKey: CodingKey {
+    var stringValue: String
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+    
+    var intValue: Int?
+    init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+}

--- a/Sources/JSONWebToken/Claims/Claims.swift
+++ b/Sources/JSONWebToken/Claims/Claims.swift
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+indirect enum Value {
+    case codable(Codable)
+    case element(ClaimElement)
+    case array([ClaimElement])
+    case object([ClaimElement])
+}
+
+/// Represents a claim element used within JWTs.
+public struct ClaimElement {
+    var key: String
+    var element: Value
+    
+    init(key: String, element: Value) {
+        self.key = key
+        self.element = element
+    }
+    
+    /// Initializes a `ClaimElement` with a codable value.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - value: The codable value of the claim.
+    public init<C: Codable>(key: String, value: C) {
+        self.key = key
+        self.element = .codable(value)
+    }
+}
+
+/// Protocol representing a claim within a JWT.
+public protocol Claim {
+    var value: ClaimElement { get }
+}
+
+/// Protocol representing a registered claim within a JWT.
+public protocol JWTRegisteredClaim: Claim {
+    var value: ClaimElement { get }
+}

--- a/Sources/JSONWebToken/Claims/DateClaim.swift
+++ b/Sources/JSONWebToken/Claims/DateClaim.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents a date claim within a JWT.
+public struct DateClaim: Claim {
+    public var value: ClaimElement
+    
+    /// Initializes a `DateClaim` with a key and a date value.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - value: The date value for the claim.
+    public init(key: String, value: Date) {
+        self.value = ClaimElement(key: key, element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/ExpirationTimeClaim.swift
+++ b/Sources/JSONWebToken/Claims/ExpirationTimeClaim.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `ExpirationTimeClaim`.
+typealias ExpClaim = ExpirationTimeClaim
+
+/// Represents the "exp" (expiration time) claim in a JWT.
+public struct ExpirationTimeClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes an `ExpirationTimeClaim` with a date value.
+    /// - Parameter value: The expiration date value for the claim.
+    public init(value: Date) {
+        self.value = ClaimElement(key: "exp", element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/IssuedAtClaim.swift
+++ b/Sources/JSONWebToken/Claims/IssuedAtClaim.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `IssuedAtClaim`.
+typealias IatClaim = IssuedAtClaim
+
+/// Represents the "iat" (issued at) claim in a JWT.
+public struct IssuedAtClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes an `IssuedAtClaim` with a date value.
+    /// - Parameter value: The issued at date value for the claim.
+    public init(value: Date) {
+        self.value = ClaimElement(key: "iat", element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/IssuerClaim.swift
+++ b/Sources/JSONWebToken/Claims/IssuerClaim.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `IssuerClaim`.
+typealias IssClaim = IssuerClaim
+
+/// Represents the "iss" (issuer) claim in a JWT.
+public struct IssuerClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes an `IssuerClaim` with a string value.
+    /// - Parameter value: The issuer value for the claim.
+    public init(value: String) {
+        self.value = ClaimElement(key: "iss", element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/JWTClaimsBuilder.swift
+++ b/Sources/JSONWebToken/Claims/JWTClaimsBuilder.swift
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A result builder for constructing JWT claims.
+@resultBuilder
+public struct JWTClaimsBuilder {
+    /// Builds a claim from the provided components.
+    /// - Parameter components: The claims to include.
+    /// - Returns: An `ObjectClaim` containing the provided claims.
+    public static func buildBlock(_ components: Claim...) -> Claim {
+        ObjectClaim(root: true, claims: components.map(\.value))
+    }
+    
+    /// Builds a claim using a closure with the result builder.
+    /// - Parameter builder: A closure that returns a claim.
+    /// - Returns: A claim built by the closure.
+    /// - Throws: Rethrows any error thrown within the builder closure.
+    public static func build(@JWTClaimsBuilder builder: () throws -> Claim) rethrows -> Claim  {
+        try builder()
+    }
+}
+
+extension Value {
+    func getValue<T>() -> T? {
+        switch self {
+        case .codable(let value):
+            return value as? T
+        default:
+            return nil
+        }
+    }
+}
+
+extension ObjectClaim: JWTRegisteredFieldsClaims {
+    var objectClaims: [ClaimElement] {
+        switch value.element {
+        case .object(let array):
+            return array
+        default:
+            return []
+        }
+    }
+    
+    public var iss: String? {
+        objectClaims.first { $0.key == "iss" }?.element.getValue()
+    }
+    
+    public var sub: String? {
+        objectClaims.first { $0.key == "sub" }?.element.getValue()
+    }
+    
+    public var aud: [String]? {
+        objectClaims.first { $0.key == "aud" }?.element.getValue()
+    }
+    
+    public var exp: Date? {
+        objectClaims.first { $0.key == "exp" }?.element.getValue()
+    }
+    
+    public var nbf: Date? {
+        objectClaims.first { $0.key == "nbf" }?.element.getValue()
+    }
+    
+    public var iat: Date? {
+        objectClaims.first { $0.key == "iat" }?.element.getValue()
+    }
+    
+    public var jti: String? {
+        objectClaims.first { $0.key == "jti" }?.element.getValue()
+    }
+    
+    public func validateExtraClaims() throws {}
+}

--- a/Sources/JSONWebToken/Claims/JWTIdentifierClaim.swift
+++ b/Sources/JSONWebToken/Claims/JWTIdentifierClaim.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `JWTIdentifierClaim`.
+typealias JtiClaim = JWTIdentifierClaim
+
+/// Represents the "jti" (JWT ID) claim in a JWT.
+public struct JWTIdentifierClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes a `JWTIdentifierClaim` with a string value.
+    /// - Parameter value: The JWT ID value for the claim.
+    public init(value: String) {
+        self.value = ClaimElement(key: "jti", element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/NotBeforeClaim.swift
+++ b/Sources/JSONWebToken/Claims/NotBeforeClaim.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `NotBeforeClaim`.
+typealias NbfClaim = NotBeforeClaim
+
+/// Represents the "nbf" (not before) claim in a JWT.
+public struct NotBeforeClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes a `NotBeforeClaim` with a date value.
+    /// - Parameter value: The not before date value for the claim.
+    public init(value: Date) {
+        self.value = ClaimElement(key: "nbf", element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/NumericClaim.swift
+++ b/Sources/JSONWebToken/Claims/NumericClaim.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents a numeric claim within a JWT.
+public struct NumberClaim: Claim {
+    public var value: ClaimElement
+    
+    /// Initializes a `NumberClaim` with a key and a numeric value.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - value: The numeric value for the claim.
+    public init<N: Numeric & Codable>(key: String, value: N) {
+        self.value = ClaimElement(key: key, element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/ObjectClaim.swift
+++ b/Sources/JSONWebToken/Claims/ObjectClaim.swift
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents an object claim within a JWT.
+public struct ObjectClaim: Claim {
+    let isRoot: Bool
+    public var value: ClaimElement
+    
+    /// A result builder for constructing object claims.
+    @resultBuilder
+    public struct ObjectClaimBuilder {
+        /// Builds an array of `Claim` from the provided components.
+        /// - Parameter components: The claims to include in the object.
+        /// - Returns: An array of `Claim`.
+        public static func buildBlock(_ components: Claim...) -> [Claim] {
+            components
+        }
+    }
+    
+    /// Initializes an `ObjectClaim` with a key and a builder for the object elements.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - claims: A closure that returns an array of `Claim` using the result builder.
+    public init(key: String, @ObjectClaimBuilder claims: () -> [Claim]) {
+        self.isRoot = false
+        self.value = .init(key: key, element: .object(claims().map(\.value)))
+    }
+    
+    init(key: String, claims: [ClaimElement]) {
+        self.isRoot = false
+        self.value = .init(key: key, element: .object(claims))
+    }
+    
+    init(root: Bool, claims: [ClaimElement]) {
+        self.isRoot = root
+        self.value = .init(key: "", element: .object(claims))
+    }
+}

--- a/Sources/JSONWebToken/Claims/StringClaim.swift
+++ b/Sources/JSONWebToken/Claims/StringClaim.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents a string claim within a JWT.
+public struct StringClaim: Claim {
+    public var value: ClaimElement
+    
+    /// Initializes a `StringClaim` with a key and a string value.
+    /// - Parameters:
+    ///   - key: The key for the claim.
+    ///   - value: The string value for the claim.
+    public init(key: String, value: String) {
+        self.value = ClaimElement(key: key, element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/Claims/SubjectClaim.swift
+++ b/Sources/JSONWebToken/Claims/SubjectClaim.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A type alias for `SubjectClaim`.
+typealias SubClaim = SubjectClaim
+
+/// Represents the "sub" (subject) claim in a JWT.
+public struct SubjectClaim: JWTRegisteredClaim {
+    public var value: ClaimElement
+    
+    /// Initializes a `SubjectClaim` with a string value.
+    /// - Parameter value: The subject value for the claim.
+    public init(value: String) {
+        self.value = ClaimElement(key: "sub", element: .codable(value))
+    }
+}

--- a/Sources/JSONWebToken/DefaultJWTClaims+Codable.swift
+++ b/Sources/JSONWebToken/DefaultJWTClaims+Codable.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-extension DefaultJWTClaimsImpl: Codable {
+extension DefaultJWTClaimsImpl {
     enum CodingKeys: String, CodingKey {
         case iss = "iss"
         case sub = "sub"

--- a/Sources/JSONWebToken/JWTRegisteredFieldsClaims.swift
+++ b/Sources/JSONWebToken/JWTRegisteredFieldsClaims.swift
@@ -16,11 +16,9 @@
 
 import Foundation
 
-typealias DefaultJWT = JWT<DefaultJWTClaimsImpl>
-
 /// `JWTRegisteredFieldsClaims` is a protocol defining the standard claims typically included in a JWT.
 /// Conforming types can represent the payload of a JWT, encompassing both registered claim names and custom claims.
-public protocol JWTRegisteredFieldsClaims: Codable {
+public protocol JWTRegisteredFieldsClaims {
     // "iss" claim representing the issuer of the JWT.
     var iss: String? { get }
     // "sub" claim representing the subject of the JWT.
@@ -42,7 +40,7 @@ public protocol JWTRegisteredFieldsClaims: Codable {
 }
 
 /// `DefaultJWTClaimsImpl` is a struct implementing the `JWTRegisteredFieldsClaims` protocol, providing a default set of claims.
-public struct DefaultJWTClaimsImpl: JWTRegisteredFieldsClaims {
+public struct DefaultJWTClaimsImpl: JWTRegisteredFieldsClaims, Codable {
     public let iss: String?
     public let sub: String?
     public let aud: [String]?

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -10,7 +10,7 @@ final class JWTTests: XCTestCase {
         eyJhbGciOiJub25lIn0.eyJpc3MiOiJ0ZXN0QWxpY2UiLCJzdWIiOiJBbGljZSIsInRlc3RDbGFpbSI6InRlc3RlZENsYWltIn0.
         """
         
-        let jwt = try JWT<DefaultJWTClaimsImpl>.verify(jwtString: jwtString)
+        let jwt = try JWT.verify(jwtString: jwtString)
         switch jwt.format {
         case .jws(let jws):
             XCTAssertEqual(jws.protectedHeader.algorithm!, .none)
@@ -20,7 +20,7 @@ final class JWTTests: XCTestCase {
             XCTFail("Wrong JWT format")
         }
         
-        XCTAssertEqual(jwt.payload.iss, "testAlice")
+        XCTAssertEqual(try JSONDecoder.jwt.decode(DefaultJWTClaimsImpl.self, from: jwt.payload).iss, "testAlice")
     }
     
     func testSignAndVerify() throws {
@@ -45,8 +45,8 @@ final class JWTTests: XCTestCase {
         XCTAssertTrue(jwtString.contains("eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"))
         XCTAssertTrue(jwtString.contains("eyJpYXQiOjIwMCwiaXNzIjoidGVzdEFsaWNlIiwic3ViIjoiQWxpY2UiLCJ0ZXN0Q2xhaW0iOiJ0ZXN0ZWRDbGFpbSJ9"))
         
-        let verifiedJWT = try JWT<MockExampleClaims>.verify(jwtString: jwtString, senderKey: key)
-        let verifiedPayload = verifiedJWT.payload
+        let verifiedJWT = try JWT.verify(jwtString: jwtString, senderKey: key)
+        let verifiedPayload = try JSONDecoder.jwt.decode(MockExampleClaims.self, from: verifiedJWT.payload)
         XCTAssertEqual(verifiedPayload.iss, "testAlice")
         XCTAssertEqual(verifiedPayload.sub, "Alice")
         XCTAssertEqual(verifiedPayload.iat, issuedAt)
@@ -77,7 +77,7 @@ final class JWTTests: XCTestCase {
         
         let jwtString = jwt.jwtString
 
-        XCTAssertThrowsError(try JWT<DefaultJWTClaimsImpl>.verify(jwtString: jwtString, senderKey: key))
+        XCTAssertThrowsError(try JWT.verify(jwtString: jwtString, senderKey: key))
     }
     
     func testFailNotBeforeValidation() throws {
@@ -98,7 +98,7 @@ final class JWTTests: XCTestCase {
         
         let jwtString = jwt.jwtString
 
-        XCTAssertThrowsError(try JWT<DefaultJWTClaimsImpl>.verify(jwtString: jwtString, senderKey: key))
+        XCTAssertThrowsError(try JWT.verify(jwtString: jwtString, senderKey: key))
     }
     
     func testFailIssuedAtValidation() throws {
@@ -119,7 +119,7 @@ final class JWTTests: XCTestCase {
         
         let jwtString = jwt.jwtString
 
-        XCTAssertThrowsError(try JWT<DefaultJWTClaimsImpl>.verify(jwtString: jwtString, senderKey: key))
+        XCTAssertThrowsError(try JWT.verify(jwtString: jwtString, senderKey: key))
     }
     
     func testFailIssuerValidation() throws {
@@ -140,7 +140,7 @@ final class JWTTests: XCTestCase {
         
         let jwtString = jwt.jwtString
 
-        XCTAssertThrowsError(try JWT<DefaultJWTClaimsImpl>.verify(
+        XCTAssertThrowsError(try JWT.verify(
             jwtString: jwtString,
             senderKey: key,
             expectedIssuer: "Bob"
@@ -164,10 +164,143 @@ final class JWTTests: XCTestCase {
         
         let jwtString = jwt.jwtString
 
-        XCTAssertThrowsError(try JWT<DefaultJWTClaimsImpl>.verify(
+        XCTAssertThrowsError(try JWT.verify(
             jwtString: jwtString,
             senderKey: key,
             expectedAudience: "Bob"
         ))
+    }
+    
+    func testClaims() throws {
+        let result = JWTClaimsBuilder.build {
+            IssuerClaim(value: "testIssuer")
+            SubjectClaim(value: "testSubject")
+            ExpirationTimeClaim(value: Date(timeIntervalSince1970: 1609459200)) // Fixed date for testing
+            IssuedAtClaim(value: Date(timeIntervalSince1970: 1609459200))
+            NotBeforeClaim(value: Date(timeIntervalSince1970: 1609459200))
+            JWTIdentifierClaim(value: "ThisIdentifier")
+            AudienceClaim(value: "testAud")
+            StringClaim(key: "testStr1", value: "value1")
+            NumberClaim(key: "testN1", value: 0)
+            NumberClaim(key: "testN2", value: 1.1)
+            NumberClaim(key: "testN3", value: Double(1.233232))
+            BoolClaim(key: "testBool1", value: true)
+            ArrayClaim(key: "testArray") {
+                ArrayElementClaim.string("valueArray1")
+                ArrayElementClaim.string("valueArray2")
+                ArrayElementClaim.bool(true)
+                ArrayElementClaim.array {
+                    ArrayElementClaim.string("nestedNestedArray1")
+                }
+                ArrayElementClaim.object {
+                    StringClaim(key: "nestedNestedObject", value: "nestedNestedValue")
+                }
+            }
+            ObjectClaim(key: "testObject") {
+                StringClaim(key: "testDicStr1", value: "valueDic1")
+            }
+        }
+        
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let coded = try encoder.encode(result.value)
+        
+        let jsonString = try XCTUnwrap(String(data: coded, encoding: .utf8))
+        print(jsonString)
+        
+        // Verify the structure of the resulting JSON
+        let expectedJSON = """
+        {
+            "aud":"testAud",
+            "exp":1609459200,
+            "iat":1609459200,
+            "iss":"testIssuer",
+            "jti":"ThisIdentifier",
+            "nbf":1609459200,
+            "sub":"testSubject",
+            "testArray":[
+                "valueArray1",
+                "valueArray2",
+                true,
+                ["nestedNestedArray1"],
+                {"nestedNestedObject":"nestedNestedValue"}
+            ],
+            "testBool1":true,
+            "testN1":0,
+            "testN2":1.1,
+            "testN3":1.233232,
+            "testObject":{"testDicStr1":"valueDic1"},
+            "testStr1":"value1"
+        }
+        """
+        
+        XCTAssertTrue(areJSONStringsEqual(jsonString, expectedJSON))
+    }
+    
+    func testEmptyClaims() throws {
+        let result = JWTClaimsBuilder.build {
+        }
+        
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let coded = try encoder.encode(result.value)
+        
+        let jsonString = try XCTUnwrap(String(data: coded, encoding: .utf8))
+        print(jsonString)
+        
+        // Verify the structure of the resulting JSON
+        let expectedJSON = "{}"
+        
+        XCTAssertTrue(areJSONStringsEqual(jsonString, expectedJSON))
+    }
+    
+    func testSingleClaim() throws {
+        let result = JWTClaimsBuilder.build {
+            IssuerClaim(value: "singleIssuer")
+        }
+        
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let coded = try encoder.encode(result.value)
+        
+        let jsonString = try XCTUnwrap(String(data: coded, encoding: .utf8))
+        print(jsonString)
+        
+        // Verify the structure of the resulting JSON
+        let expectedJSON = """
+        {
+            "iss":"singleIssuer"
+        }
+        """
+        
+        XCTAssertTrue(areJSONStringsEqual(jsonString, expectedJSON))
+    }
+    
+    private func areJSONStringsEqual(_ lhs: String, _ rhs: String) -> Bool {
+        guard
+            let lhsData = lhs.data(using: .utf8),
+            let rhsData = rhs.data(using: .utf8),
+            let lhsObject = try? JSONSerialization.jsonObject(with: lhsData, options: []),
+            let rhsObject = try? JSONSerialization.jsonObject(with: rhsData, options: [])
+        else {
+            return false
+        }
+        return NSDictionary(dictionary: lhsObject as? [String: Any] ?? [:])
+            .isEqual(to: rhsObject as? [String: Any] ?? [:])
+    }
+}
+
+extension String {
+    /// Returns a new string with all whitespace and newline characters removed.
+    ///
+    /// This method creates a new string with all occurrences of whitespace and newline characters (spaces and line breaks) removed. The original string is not modified.
+    ///
+    /// - Returns: A new string with all whitespace and newline characters removed.
+    func replacingWhiteSpacesAndNewLines() -> String {
+        replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
     }
 }

--- a/Tests/JWTTests/Mock/MockExampleClaims.swift
+++ b/Tests/JWTTests/Mock/MockExampleClaims.swift
@@ -1,7 +1,7 @@
 import Foundation
 import JSONWebToken
 
-struct MockExampleClaims: JWTRegisteredFieldsClaims {
+struct MockExampleClaims: JWTRegisteredFieldsClaims, Codable {
     let iss: String?
     let sub: String?
     let aud: [String]?


### PR DESCRIPTION
This feature will add the ability of creating JWTs claims with DSL.

Example:

```
let jwt = try JWT.signed(
        payload: {
            IssuerClaim(value: "testIssuer")
            SubjectClaim(value: "testSubject")
            ExpirationTimeClaim(value: Date())
            IssuedAtClaim(value: Date())
            NotBeforeClaim(value: Date())
            JWTIdentifierClaim(value: "ThisIdentifier")
            AudienceClaim(value: "testAud")
        },
        protectedHeader: DefaultJWSHeaderImpl(algorithm: .ES256),
        key: key
    ).jwtString
```