### PR TITLE
feat(jws): introduce new methods to use data and seckey as keys

### DIFF
--- a/Sources/JSONWebAlgorithms/Compression/ZIP/Zip+ContentCompressor.swift
+++ b/Sources/JSONWebAlgorithms/Compression/ZIP/Zip+ContentCompressor.swift
@@ -16,12 +16,21 @@
 
 import Foundation
 
-struct Zip: ContentCompressor, ContentDecompressor {
-    func compress(input: Data) throws -> Data {
+/// `Zip` provides methods to compress and decompress data using zlib.
+public struct Zip: ContentCompressor, ContentDecompressor {
+    /// Compresses the input data using zlib.
+    /// - Parameter input: The data to be compressed.
+    /// - Throws: An error if the compression fails.
+    /// - Returns: The compressed data.
+    public func compress(input: Data) throws -> Data {
         try (input as NSData).compressed(using: .zlib) as Data
     }
     
-    func decompress(input: Data) throws -> Data {
+    /// Decompresses the input data using zlib.
+    /// - Parameter input: The data to be decompressed.
+    /// - Throws: An error if the decompression fails.
+    /// - Returns: The decompressed data.
+    public func decompress(input: Data) throws -> Data {
         try (input as NSData).decompressed(using: .zlib) as Data
     }
 }

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/AES128GCM+ContentEncryptor.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/AES128GCM+ContentEncryptor.swift
@@ -17,21 +17,37 @@
 import CryptoKit
 import Foundation
 
-struct AES128GCM: ContentEncryptor, ContentDecryptor {
+/// `AES128GCM` provides methods to encrypt and decrypt data using AES-128-GCM.
+public struct AES128GCM: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a128GCM.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a128GCM.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.a128GCM.keySizeInBits
     
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a128GCM.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a128GCM.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.a128GCM.keySizeInBits
-    
-    func generateInitializationVector() throws -> Data {
-        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits)
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
+        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(
+    /// Encrypts the payload using AES-128-GCM.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
         payload: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -45,7 +61,14 @@ struct AES128GCM: ContentEncryptor, ContentDecryptor {
         return .init(cipher: cipher, authenticationData: tag)
     }
     
-    func decrypt(
+    /// Decrypts the cipher text using AES-128-GCM.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails.
+    /// - Returns: The decrypted data.
+    public func decrypt(
         cipher: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/AES192GCM+ContentEncryptor.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/AES192GCM+ContentEncryptor.swift
@@ -17,20 +17,37 @@
 import CryptoKit
 import Foundation
 
-struct AES192GCM: ContentEncryptor, ContentDecryptor {
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a192GCM.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a192GCM.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.a192GCM.keySizeInBits
+/// `AES192GCM` provides methods to encrypt and decrypt data using AES-192-GCM.
+public struct AES192GCM: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a192GCM.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a192GCM.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.a192GCM.keySizeInBits
     
-    func generateInitializationVector() throws -> Data {
-        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits)
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
+        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(
+    /// Encrypts the payload using AES-192-GCM.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
         payload: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -44,7 +61,14 @@ struct AES192GCM: ContentEncryptor, ContentDecryptor {
         return .init(cipher: cipher, authenticationData: tag)
     }
     
-    func decrypt(
+    /// Decrypts the cipher text using AES-192-GCM.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails.
+    /// - Returns: The decrypted data.
+    public func decrypt(
         cipher: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/AES256GCM+ContentEncryptor.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/AES256GCM+ContentEncryptor.swift
@@ -17,21 +17,37 @@
 import CryptoKit
 import Foundation
 
-struct AES256GCM: ContentEncryptor, ContentDecryptor {
+/// `AES256GCM` provides methods to encrypt and decrypt data using AES-256-GCM.
+public struct AES256GCM: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a256GCM.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a256GCM.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.a256GCM.keySizeInBits
     
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a256GCM.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a256GCM.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.a256GCM.keySizeInBits
-    
-    func generateInitializationVector() throws -> Data {
-        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits)
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
+        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(
+    /// Encrypts the payload using AES-256-GCM.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
         payload: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -45,7 +61,14 @@ struct AES256GCM: ContentEncryptor, ContentDecryptor {
         return .init(cipher: cipher, authenticationData: tag)
     }
     
-    func decrypt(
+    /// Decrypts the cipher text using AES-256-GCM.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails.
+    /// - Returns: The decrypted data.
+    public func decrypt(
         cipher: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/AESCBC_SHA256+ContentEncryptor.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/AESCBC_SHA256+ContentEncryptor.swift
@@ -18,21 +18,37 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct AESCBC_SHA256: ContentEncryptor, ContentDecryptor {
+/// `AESCBC_SHA256` provides methods to encrypt and decrypt data using AES-CBC with SHA-256 for authentication.
+public struct AESCBC_SHA256: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a128CBCHS256.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a128CBCHS256.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.a128CBCHS256.keySizeInBits
     
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a128CBCHS256.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a128CBCHS256.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.a128CBCHS256.keySizeInBits
-    
-    func generateInitializationVector() throws -> Data {
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
         try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(
+    /// Encrypts the payload using AES-CBC with SHA-256 for authentication.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails or if the initialization vector is missing or of incorrect size.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
         payload: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -60,7 +76,14 @@ struct AESCBC_SHA256: ContentEncryptor, ContentDecryptor {
         return .init(cipher: cipher, authenticationData: tag)
     }
     
-    func decrypt(
+    /// Decrypts the cipher text using AES-CBC with SHA-256 for authentication.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails or if required arguments are missing.
+    /// - Returns: The decrypted data.
+    public func decrypt(
         cipher: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -79,7 +102,7 @@ struct AESCBC_SHA256: ContentEncryptor, ContentDecryptor {
         
         return try AESCBC_SHA<SHA256>.decrypt(
             cipher: cipher,
-            cek: key, 
+            cek: key,
             authenticationTagLength: 16,
             initializationVector: iv,
             additionalAuthenticatedData: aad,

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/AESCBC_SHA384+ContentEncryptor.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/AESCBC_SHA384+ContentEncryptor.swift
@@ -17,21 +17,37 @@
 import CryptoKit
 import Foundation
 
-struct AESCBC_SHA384: ContentEncryptor, ContentDecryptor {
+/// `AESCBC_SHA384` provides methods to encrypt and decrypt data using AES-CBC with SHA-384 for authentication.
+public struct AESCBC_SHA384: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a192CBCHS384.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a192CBCHS384.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.a192CBCHS384.keySizeInBits
     
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a192CBCHS384.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a192CBCHS384.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.a192CBCHS384.keySizeInBits
-    
-    func generateInitializationVector() throws -> Data {
-        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits)
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
+        try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(
+    /// Encrypts the payload using AES-CBC with SHA-384 for authentication.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails or if the initialization vector is missing or of incorrect size.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
         payload: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -59,7 +75,14 @@ struct AESCBC_SHA384: ContentEncryptor, ContentDecryptor {
         return .init(cipher: cipher, authenticationData: tag)
     }
     
-    func decrypt(
+    /// Decrypts the cipher text using AES-CBC with SHA-384 for authentication.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails or if required arguments are missing.
+    /// - Returns: The decrypted data.
+    public func decrypt(
         cipher: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/AESCBC_SHA512+ContentEncryptor.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/AESCBC_SHA512+ContentEncryptor.swift
@@ -17,21 +17,37 @@
 import CryptoKit
 import Foundation
 
-struct AESCBC_SHA512: ContentEncryptor, ContentDecryptor {
+/// `AESCBC_SHA512` provides methods to encrypt and decrypt data using AES-CBC with SHA-512 for authentication.
+public struct AESCBC_SHA512: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a256CBCHS512.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a256CBCHS512.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.a256CBCHS512.keySizeInBits
     
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.a256CBCHS512.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.a256CBCHS512.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.a256CBCHS512.keySizeInBits
-    
-    func generateInitializationVector() throws -> Data {
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
         try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(
+    /// Encrypts the payload using AES-CBC with SHA-512 for authentication.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails or if the initialization vector is missing or of incorrect size.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
         payload: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]
@@ -59,7 +75,14 @@ struct AESCBC_SHA512: ContentEncryptor, ContentDecryptor {
         return .init(cipher: cipher, authenticationData: tag)
     }
     
-    func decrypt(
+    /// Decrypts the cipher text using AES-CBC with SHA-512 for authentication.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails or if required arguments are missing.
+    /// - Returns: The decrypted data.
+    public func decrypt(
         cipher: Data,
         using key: Data,
         arguments: [ContentEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/ContentEncryption/AES/XC20P+ContentEncryption.swift
+++ b/Sources/JSONWebAlgorithms/ContentEncryption/AES/XC20P+ContentEncryption.swift
@@ -1,21 +1,41 @@
 import CryptoKit
 import Foundation
 
-struct C20PKW: ContentEncryptor, ContentDecryptor {
+/// `C20PKW` provides methods to encrypt and decrypt data using the ChaCha20-Poly1305 algorithm.
+public struct C20PKW: ContentEncryptor, ContentDecryptor {
+    /// The content encryption algorithm used, represented as a string.
+    public let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.c20PKW.rawValue
+    /// The size of the initialization vector in bits.
+    public let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.c20PKW.initializationVectorSizeInBits
+    /// The size of the content encryption key (CEK) in bits.
+    public let cekKeySize: Int = ContentEncryptionAlgorithm.c20PKW.keySizeInBits
     
-    let contentEncryptionAlgorithm: String = ContentEncryptionAlgorithm.c20PKW.rawValue
-    let initializationVectorSizeInBits: Int = ContentEncryptionAlgorithm.c20PKW.initializationVectorSizeInBits
-    let cekKeySize: Int = ContentEncryptionAlgorithm.c20PKW.keySizeInBits
-    
-    func generateInitializationVector() throws -> Data {
+    /// Generates a random initialization vector.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the initialization vector.
+    public func generateInitializationVector() throws -> Data {
         try SecureRandom.secureRandomData(count: initializationVectorSizeInBits / 8)
     }
     
-    func generateCEK() throws -> Data {
+    /// Generates a random content encryption key (CEK).
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A data object containing the CEK.
+    public func generateCEK() throws -> Data {
         try SecureRandom.secureRandomData(count: cekKeySize / 8)
     }
     
-    func encrypt(payload: Data, using key: Data, arguments: [ContentEncryptionArguments]) throws -> ContentEncryptionResult {
+    /// Encrypts the payload using the ChaCha20-Poly1305 algorithm.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - key: The encryption key.
+    ///   - arguments: Additional encryption arguments, such as initialization vector and additional authenticated data.
+    /// - Throws: An error if the encryption fails or if required arguments are missing or of incorrect size.
+    /// - Returns: A `ContentEncryptionResult` containing the cipher text and authentication tag.
+    public func encrypt(
+        payload: Data,
+        using key: Data,
+        arguments: [ContentEncryptionArguments]
+    ) throws -> ContentEncryptionResult {
         guard let iv = arguments.initializationVector else {
             throw CryptoError.missingInitializationVector
         }
@@ -38,7 +58,18 @@ struct C20PKW: ContentEncryptor, ContentDecryptor {
         return .init(cipher: aead.ciphertext, authenticationData: aead.tag)
     }
     
-    func decrypt(cipher: Data, using key: Data, arguments: [ContentEncryptionArguments]) throws -> Data {
+    /// Decrypts the cipher text using the ChaCha20-Poly1305 algorithm.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - key: The decryption key.
+    ///   - arguments: Additional decryption arguments, such as initialization vector and authentication tag.
+    /// - Throws: An error if the decryption fails or if required arguments are missing.
+    /// - Returns: The decrypted data.
+    public func decrypt(
+        cipher: Data,
+        using key: Data,
+        arguments: [ContentEncryptionArguments]
+    ) throws -> Data {
         guard let iv = arguments.initializationVector else {
             throw CryptoError.missingInitializationVector
         }

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/AES/AESCBC_SHA.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/AES/AESCBC_SHA.swift
@@ -20,9 +20,19 @@ import Foundation
 import JSONWebKey
 import Tools
 
-struct AESCBC_SHA<H: HashFunction> {
+/// `AESCBC_SHA` provides methods to encrypt and decrypt data using AES-CBC with an HMAC for authentication.
+public struct AESCBC_SHA<H: HashFunction> {
     
-    static func encrypt(
+    /// Encrypts the payload using AES-CBC with an HMAC for authentication.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - cek: The content encryption key.
+    ///   - authenticationTagLength: The length of the authentication tag.
+    ///   - initializationVector: The initialization vector (default is empty data).
+    ///   - additionalAuthenticatedData: Additional data to be authenticated (default is empty data).
+    /// - Throws: An error if the encryption fails.
+    /// - Returns: A tuple containing the cipher text and authentication tag.
+    public static func encrypt(
         payload: Data,
         cek: Data,
         authenticationTagLength: Int,
@@ -54,7 +64,17 @@ struct AESCBC_SHA<H: HashFunction> {
         return (Data(ciphertext), authenticationTag)
     }
     
-    static func decrypt(
+    /// Decrypts the cipher text using AES-CBC with an HMAC for authentication.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - cek: The content encryption key.
+    ///   - authenticationTagLength: The length of the authentication tag.
+    ///   - initializationVector: The initialization vector.
+    ///   - additionalAuthenticatedData: Additional data to be authenticated.
+    ///   - authenticationTag: The authentication tag.
+    /// - Throws: An error if the decryption fails or if the authentication tag doesn't match.
+    /// - Returns: The decrypted data.
+    public static func decrypt(
         cipher: Data,
         cek: Data,
         authenticationTagLength: Int,

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/AES/AESGCM.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/AES/AESGCM.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import Tools
 
-struct AESGCM {
+/// `AESGCM` provides methods to encrypt and decrypt data using AES-GCM (Galois/Counter Mode).
+public struct AESGCM {
     
-    static func encrypt(
+    /// Encrypts the payload using AES-GCM.
+    /// - Parameters:
+    ///   - payload: The data to be encrypted.
+    ///   - cek: The content encryption key.
+    ///   - initializationVector: The initialization vector (default is empty data).
+    ///   - additionalAuthenticatedData: Additional data to be authenticated (default is empty data).
+    /// - Throws: An error if the encryption fails.
+    /// - Returns: A tuple containing the cipher text and authentication tag.
+    public static func encrypt(
         payload: Data,
         cek: Data,
         initializationVector: Data = Data(),
@@ -35,7 +44,16 @@ struct AESGCM {
         return (sealedBox.ciphertext, sealedBox.tag)
     }
     
-    static func decrypt(
+    /// Decrypts the cipher text using AES-GCM.
+    /// - Parameters:
+    ///   - cipher: The data to be decrypted.
+    ///   - using: The decryption key.
+    ///   - initializationVector: The initialization vector (default is empty data).
+    ///   - authenticationTag: The authentication tag (default is empty data).
+    ///   - additionalAuthenticatedData: Additional data to be authenticated (default is empty data).
+    /// - Throws: An error if the decryption fails.
+    /// - Returns: The decrypted data.
+    public static func decrypt(
         cipher: Data,
         using: Data,
         initializationVector: Data = Data(),

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/ConcatKDF/ConcatKDF.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/ConcatKDF/ConcatKDF.swift
@@ -10,21 +10,21 @@ import CryptoKit
 import Foundation
 
 /// A protocol representing a hash function that has a maximum input length.
-protocol HashFunctionMaxInputLength {
+public protocol HashFunctionMaxInputLength {
     static var maxInputLength: UInt64 { get }
 }
 
 extension SHA256: HashFunctionMaxInputLength {
-    static var maxInputLength: UInt64 { UInt64.max - 1 }
+    public static var maxInputLength: UInt64 { UInt64.max - 1 }
 }
 
 /// An enumeration that represents the possible errors that can occur during the Concat KDF key derivation.
-enum ConcatKDFError: Error {
+public enum ConcatKDFError: Error {
     case invalidInput
 }
 
 /// The Concat Key Derivation Function (KDF), as defined in Section 5.8.1 of [NIST.800-56A](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf)
-struct ConcatKDF<H> where H: HashFunction, H: HashFunctionMaxInputLength {
+public struct ConcatKDF<H> where H: HashFunction, H: HashFunctionMaxInputLength {
     /// Derives a symmetric key using the Concat KDF algorithm.
     ///
     /// - Parameters:
@@ -39,7 +39,7 @@ struct ConcatKDF<H> where H: HashFunction, H: HashFunctionMaxInputLength {
     /// - Returns: The derived symmetric key.
     ///
     /// - Throws: An error if any issues occur during the derivation process.
-    static func deriveKey(
+    public static func deriveKey(
         z: Data,
         keyDataLen: Int,
         algorithmID: Data,

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/ECDH/ECDH1PU.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/ECDH/ECDH1PU.swift
@@ -18,8 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct ECDH1PU {
-    func processSharedKey(
+/// `ECDH1PU` provides methods to process a shared key using ECDH-1PU (Ephemeral Static Diffie-Hellman over One-Pass Unified Model).
+public struct ECDH1PU {
+    
+    /// Processes a shared key using the given private, public, and ephemeral keys.
+    /// - Parameters:
+    ///   - privateKey: The private key as a JWK.
+    ///   - publicKey: The public key as a JWK.
+    ///   - ephemeralKey: The ephemeral key as a JWK.
+    ///   - sender: A boolean indicating if the sender is processing the shared key.
+    /// - Throws: An error if the key agreement fails or if the private key is not valid.
+    /// - Returns: The combined shared secret as a `Data` object.
+    public func processSharedKey(
         privateKey: JWK,
         publicKey: JWK,
         ephemeralKey: JWK,

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/ECDH/ECDHES.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/ECDH/ECDHES.swift
@@ -18,8 +18,16 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct ECDHES {
-    func processSharedKey(
+/// `ECDHES` provides methods to process a shared key using ECDH-ES (Elliptic Curve Diffie-Hellman Ephemeral Static).
+public struct ECDHES {
+    
+    /// Processes a shared key using the given private and public keys.
+    /// - Parameters:
+    ///   - privateKey: The private key as a JWK.
+    ///   - publicKey: The public key as a JWK.
+    /// - Throws: An error if the key agreement fails or if the private key is not valid.
+    /// - Returns: The shared secret as a `Data` object.
+    public func processSharedKey(
         privateKey: JWK,
         publicKey: JWK
     ) throws -> Data {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/Curve25519/Curve25519+KeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/Curve25519/Curve25519+KeyAgreement.swift
@@ -18,7 +18,13 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `Curve25519.KeyAgreement.PrivateKey` conform to `SharedKeyAgreement`.
 extension Curve25519.KeyAgreement.PrivateKey: SharedKeyAgreement {
+    
+    /// Computes the shared secret from the key agreement with the provided public key share.
+    /// - Parameter publicKeyShare: The public key share as a `JWK`.
+    /// - Throws: An error if the conversion to `Curve25519.KeyAgreement.PublicKey` fails or the key agreement fails.
+    /// - Returns: The shared secret as a `Data` object.
     public func sharedSecretFromKeyAgreement(
         publicKeyShare: JWK
     ) throws -> Data {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/P256+KeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/P256+KeyAgreement.swift
@@ -18,7 +18,13 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `P256.KeyAgreement.PrivateKey` conform to `SharedKeyAgreement`.
 extension P256.KeyAgreement.PrivateKey: SharedKeyAgreement {
+    
+    /// Computes the shared secret from the key agreement with the provided public key share.
+    /// - Parameter publicKeyShare: The public key share as a `JWK`.
+    /// - Throws: An error if the conversion to `P256.KeyAgreement.PublicKey` fails or the key agreement fails.
+    /// - Returns: The shared secret as a `Data` object.
     public func sharedSecretFromKeyAgreement(
         publicKeyShare: JWK
     ) throws -> Data {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/P384+KeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/P384+KeyAgreement.swift
@@ -18,7 +18,13 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `P384.KeyAgreement.PrivateKey` conform to `SharedKeyAgreement`.
 extension P384.KeyAgreement.PrivateKey: SharedKeyAgreement {
+    
+    /// Computes the shared secret from the key agreement with the provided public key share.
+    /// - Parameter publicKeyShare: The public key share as a `JWK`.
+    /// - Throws: An error if the conversion to `P384.KeyAgreement.PublicKey` fails or the key agreement fails.
+    /// - Returns: The shared secret as a `Data` object.
     public func sharedSecretFromKeyAgreement(
         publicKeyShare: JWK
     ) throws -> Data {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/P521+KeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/P521+KeyAgreement.swift
@@ -18,7 +18,13 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `P521.KeyAgreement.PrivateKey` conform to `SharedKeyAgreement`.
 extension P521.KeyAgreement.PrivateKey: SharedKeyAgreement {
+    
+    /// Computes the shared secret from the key agreement with the provided public key share.
+    /// - Parameter publicKeyShare: The public key share as a `JWK`.
+    /// - Throws: An error if the conversion to `P521.KeyAgreement.PublicKey` fails or the key agreement fails.
+    /// - Returns: The shared secret as a `Data` object.
     public func sharedSecretFromKeyAgreement(
         publicKeyShare: JWK
     ) throws -> Data {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/secp256k1+KeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/EC/secp256k1+KeyAgreement.swift
@@ -18,7 +18,13 @@ import Foundation
 import JSONWebKey
 import secp256k1
 
+/// Extension to make `secp256k1.KeyAgreement.PrivateKey` conform to `SharedKeyAgreement`.
 extension secp256k1.KeyAgreement.PrivateKey: SharedKeyAgreement {
+    
+    /// Computes the shared secret from the key agreement with the provided public key share.
+    /// - Parameter publicKeyShare: The public key share as a `JWK`.
+    /// - Throws: An error if the conversion to `secp256k1.KeyAgreement.PublicKey` fails or the key agreement fails.
+    /// - Returns: The shared secret as a `Data` object.
     public func sharedSecretFromKeyAgreement(
         publicKeyShare: JWK
     ) throws -> Data {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/JWK+KeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/JWK+KeyAgreement.swift
@@ -20,7 +20,9 @@ import JSONWebKey
 import secp256k1
 
 extension JWK {
-    var keyAgreement: SharedKeyAgreement? {
+    /// A computed property that returns a `SharedKeyAgreement` object if the JWK supports key agreement.
+    /// - Returns: An optional `SharedKeyAgreement` object, or `nil` if the JWK does not support key agreement.
+    public var keyAgreement: SharedKeyAgreement? {
         switch keyType {
         case .ellipticCurve:
             switch curve {

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/SharedKeyAgreement.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyAgreement/SharedKeyAgreement.swift
@@ -17,6 +17,6 @@
 import Foundation
 import JSONWebKey
 
-protocol SharedKeyAgreement {
+public protocol SharedKeyAgreement {
     func sharedSecretFromKeyAgreement(publicKeyShare: JWK) throws -> Data
 }

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/Curve25519/Curve25519+KeyGeneration.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/Curve25519/Curve25519+KeyGeneration.swift
@@ -18,11 +18,20 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct Curve25519KeyGeneration: KeyGeneration {
+/// `Curve25519KeyGeneration` provides methods to generate random keys, private keys, and key pairs in JWK format for Curve25519.
+public struct Curve25519KeyGeneration: KeyGeneration {
+    
+    /// Generates a random key.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A `Data` object containing the generated random key.
     public func generateRandomKey() throws -> Data {
         return try SecureRandom.secureRandomData(count: 32)
     }
     
+    /// Generates a private key for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `Data` object containing the generated private key.
     public func generatePrivateKey(purpose: KeyGenerationPurpose) throws -> Data {
         switch purpose {
         case .signing:
@@ -32,6 +41,10 @@ struct Curve25519KeyGeneration: KeyGeneration {
         }
     }
     
+    /// Generates a key pair in JWK format for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key pair is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `JWK` object containing the generated key pair.
     public func generateKeyPairJWK(purpose: KeyGenerationPurpose) throws -> JWK {
         switch purpose {
         case .signing:

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/P256+KeyGeneration.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/P256+KeyGeneration.swift
@@ -18,12 +18,20 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct P256KeyGeneration: KeyGeneration {
+/// `P256KeyGeneration` provides methods to generate random keys, private keys, and key pairs in JWK format for P-256.
+public struct P256KeyGeneration: KeyGeneration {
 
+    /// Generates a random key.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A `Data` object containing the generated random key.
     public func generateRandomKey() throws -> Data {
         return try SecureRandom.secureRandomData(count: 32)
     }
 
+    /// Generates a private key for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `Data` object containing the generated private key.
     public func generatePrivateKey(purpose: KeyGenerationPurpose) throws -> Data {
         switch purpose {
         case .signing:
@@ -33,6 +41,10 @@ struct P256KeyGeneration: KeyGeneration {
         }
     }
 
+    /// Generates a key pair in JWK format for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key pair is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `JWK` object containing the generated key pair.
     public func generateKeyPairJWK(purpose: KeyGenerationPurpose) throws -> JWK {
         switch purpose {
         case .signing:

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/P384+KeyGeneration.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/P384+KeyGeneration.swift
@@ -18,12 +18,20 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct P384KeyGeneration: KeyGeneration {
+/// `P384KeyGeneration` provides methods to generate random keys, private keys, and key pairs in JWK format for P-384.
+public struct P384KeyGeneration: KeyGeneration {
 
+    /// Generates a random key.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A `Data` object containing the generated random key.
     public func generateRandomKey() throws -> Data {
         return try SecureRandom.secureRandomData(count: 48)
     }
 
+    /// Generates a private key for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `Data` object containing the generated private key.
     public func generatePrivateKey(purpose: KeyGenerationPurpose) throws -> Data {
         switch purpose {
         case .signing:
@@ -33,6 +41,10 @@ struct P384KeyGeneration: KeyGeneration {
         }
     }
 
+    /// Generates a key pair in JWK format for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key pair is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `JWK` object containing the generated key pair.
     public func generateKeyPairJWK(purpose: KeyGenerationPurpose) throws -> JWK {
         switch purpose {
         case .signing:

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/P521+KeyGeneration.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/P521+KeyGeneration.swift
@@ -18,12 +18,20 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
-struct P521KeyGeneration: KeyGeneration {
+/// `P521KeyGeneration` provides methods to generate random keys, private keys, and key pairs in JWK format for P-521.
+public struct P521KeyGeneration: KeyGeneration {
 
+    /// Generates a random key.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A `Data` object containing the generated random key.
     public func generateRandomKey() throws -> Data {
         return try SecureRandom.secureRandomData(count: 66)
     }
 
+    /// Generates a private key for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `Data` object containing the generated private key.
     public func generatePrivateKey(purpose: KeyGenerationPurpose) throws -> Data {
         switch purpose {
         case .signing:
@@ -33,6 +41,10 @@ struct P521KeyGeneration: KeyGeneration {
         }
     }
 
+    /// Generates a key pair in JWK format for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key pair is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `JWK` object containing the generated key pair.
     public func generateKeyPairJWK(purpose: KeyGenerationPurpose) throws -> JWK {
         switch purpose {
         case .signing:

--- a/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/secp256k1+KeyGeneration.swift
+++ b/Sources/JSONWebAlgorithms/CryptoImplementation/KeyGeneration/EC/secp256k1+KeyGeneration.swift
@@ -18,12 +18,20 @@ import Foundation
 import JSONWebKey
 import secp256k1
 
-struct Secp256k1KeyGeneration: KeyGeneration {
+/// `Secp256k1KeyGeneration` provides methods to generate random keys, private keys, and key pairs in JWK format for secp256k1.
+public struct Secp256k1KeyGeneration: KeyGeneration {
 
+    /// Generates a random key.
+    /// - Throws: An error if the random data generation fails.
+    /// - Returns: A `Data` object containing the generated random key.
     public func generateRandomKey() throws -> Data {
         return try SecureRandom.secureRandomData(count: 32)
     }
 
+    /// Generates a private key for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `Data` object containing the generated private key.
     public func generatePrivateKey(purpose: KeyGenerationPurpose) throws -> Data {
         switch purpose {
         case .signing:
@@ -33,6 +41,10 @@ struct Secp256k1KeyGeneration: KeyGeneration {
         }
     }
 
+    /// Generates a key pair in JWK format for the specified purpose.
+    /// - Parameter purpose: The purpose for which the key pair is generated (`signing` or `keyAgreement`).
+    /// - Throws: An error if the key generation fails.
+    /// - Returns: A `JWK` object containing the generated key pair.
     public func generateKeyPairJWK(purpose: KeyGenerationPurpose) throws -> JWK {
         switch purpose {
         case .signing:

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyAgreement/ECDH/ECDH1PU+KeyAgreementZ.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyAgreement/ECDH/ECDH1PU+KeyAgreementZ.swift
@@ -17,8 +17,18 @@
 import Foundation
 import JSONWebKey
 
+/// Extension to make `ECDH1PU` conform to `KeyAgreementZ`.
 extension ECDH1PU: KeyAgreementZ {
-    func agreeUponZ(privateKey: JWK, publicKey: JWK, ephemeralKey: JWK?, sender: Bool) throws -> Data {
+    
+    /// Agrees upon a shared secret `Z` using the given private, public, and ephemeral keys.
+    /// - Parameters:
+    ///   - privateKey: The private key as a `JWK`.
+    ///   - publicKey: The public key as a `JWK`.
+    ///   - ephemeralKey: The ephemeral key as a `JWK`. This parameter is required.
+    ///   - sender: A boolean indicating if the sender is agreeing upon the shared secret.
+    /// - Throws: An error if the key agreement fails or if the ephemeral key is missing.
+    /// - Returns: The agreed upon shared secret `Z` as a `Data` object.
+    public func agreeUponZ(privateKey: JWK, publicKey: JWK, ephemeralKey: JWK?, sender: Bool) throws -> Data {
         guard let ephemeralKey else {
             throw CryptoError.missingArguments([])
         }

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyAgreement/ECDH/ECDHES+KeyAgreementZ.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyAgreement/ECDH/ECDHES+KeyAgreementZ.swift
@@ -17,8 +17,18 @@
 import Foundation
 import JSONWebKey
 
+/// Extension to make `ECDHES` conform to `KeyAgreementZ`.
 extension ECDHES: KeyAgreementZ {
-    func agreeUponZ(privateKey: JWK, publicKey: JWK, ephemeralKey: JWK?, sender: Bool) throws -> Data {
+    
+    /// Agrees upon a shared secret `Z` using the given private and public keys.
+    /// - Parameters:
+    ///   - privateKey: The private key as a `JWK`.
+    ///   - publicKey: The public key as a `JWK`.
+    ///   - ephemeralKey: The ephemeral key as a `JWK`. This parameter is optional and not used in this implementation.
+    ///   - sender: A boolean indicating if the sender is agreeing upon the shared secret. This parameter is not used in this implementation.
+    /// - Throws: An error if the key agreement fails.
+    /// - Returns: The agreed upon shared secret `Z` as a `Data` object.
+    public func agreeUponZ(privateKey: JWK, publicKey: JWK, ephemeralKey: JWK?, sender: Bool) throws -> Data {
         return try processSharedKey(privateKey: privateKey, publicKey: publicKey)
     }
 }

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/ECDH/ECDH1PU+KeyDerivation.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/ECDH/ECDH1PU+KeyDerivation.swift
@@ -18,9 +18,14 @@ import CryptoKit
 import Foundation
 import Tools
 
+/// Extension to make `ECDH1PU` conform to `KeyDerivation`.
 extension ECDH1PU: KeyDerivation {
     
-    func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
+    /// Derives a key using the provided key derivation arguments.
+    /// - Parameter arguments: An array of `KeyDerivationArguments` containing the necessary parameters for key derivation.
+    /// - Throws: An error if required arguments are missing or if the key derivation fails.
+    /// - Returns: The derived key as a `Data` object.
+    public func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
         guard let key = arguments.key else {
             throw CryptoError.missingArguments(["key"])
         }

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/ECDH/ECDHES+KeyDerivation.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/ECDH/ECDHES+KeyDerivation.swift
@@ -18,9 +18,14 @@ import CryptoKit
 import Foundation
 import Tools
 
+/// Extension to make `ECDHES` conform to `KeyDerivation`.
 extension ECDHES: KeyDerivation {
     
-    func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
+    /// Derives a key using the provided key derivation arguments.
+    /// - Parameter arguments: An array of `KeyDerivationArguments` containing the necessary parameters for key derivation.
+    /// - Throws: An error if required arguments are missing or if the key derivation fails.
+    /// - Returns: The derived key as a `Data` object.
+    public func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
         guard let key = arguments.key else {
             throw CryptoError.missingArguments(["key"])
         }

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBE2_SHA256_A128KW+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBE2_SHA256_A128KW+KeyEncryption.swift
@@ -17,18 +17,18 @@
 import Foundation
 import JSONWebKey
 
+/// `PBE2_SHA256_A128KW` provides methods to derive a key using the PBES2-HMAC-SHA256 algorithm with AES key wrapping.
 struct PBE2_SHA256_A128KW: KeyDerivation {
     
-    func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
-        guard
-            let password = arguments.password
-        else {
+    /// Derives a key using the provided key derivation arguments.
+    /// - Parameter arguments: An array of `KeyDerivationArguments` containing the necessary parameters for key derivation.
+    /// - Throws: An error if required arguments are missing or if the key derivation fails.
+    /// - Returns: The derived key as a `Data` object.
+    public func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
+        guard let password = arguments.password else {
             throw CryptoError.missingArguments(["password"])
         }
-        guard
-            let salt = arguments.saltInput,
-            let count = arguments.saltCount
-        else {
+        guard let salt = arguments.saltInput, let count = arguments.saltCount else {
             throw CryptoError.missingPBS2SaltInputOrCount
         }
         

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBE2_SHA384_A192KW+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBE2_SHA384_A192KW+KeyEncryption.swift
@@ -17,18 +17,18 @@
 import Foundation
 import JSONWebKey
 
+/// `PBE2_SHA384_A192KW` provides methods to derive a key using the PBES2-HMAC-SHA384 algorithm with AES key wrapping.
 struct PBE2_SHA384_A192KW: KeyDerivation {
     
-    func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
-        guard
-            let password = arguments.password
-        else {
+    /// Derives a key using the provided key derivation arguments.
+    /// - Parameter arguments: An array of `KeyDerivationArguments` containing the necessary parameters for key derivation.
+    /// - Throws: An error if required arguments are missing or if the key derivation fails.
+    /// - Returns: The derived key as a `Data` object.
+    public func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
+        guard let password = arguments.password else {
             throw CryptoError.missingArguments(["password"])
         }
-        guard
-            let salt = arguments.saltInput,
-            let count = arguments.saltCount
-        else {
+        guard let salt = arguments.saltInput, let count = arguments.saltCount else {
             throw CryptoError.missingPBS2SaltInputOrCount
         }
         

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBE2_SHA512_A256KW+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBE2_SHA512_A256KW+KeyEncryption.swift
@@ -17,18 +17,18 @@
 import Foundation
 import JSONWebKey
 
+/// `PBE2_SHA512_A256KW` provides methods to derive a key using the PBES2-HMAC-SHA512 algorithm with AES key wrapping.
 struct PBE2_SHA512_A256KW: KeyDerivation {
     
-    func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
-        guard
-            let password = arguments.password
-        else {
+    /// Derives a key using the provided key derivation arguments.
+    /// - Parameter arguments: An array of `KeyDerivationArguments` containing the necessary parameters for key derivation.
+    /// - Throws: An error if required arguments are missing or if the key derivation fails.
+    /// - Returns: The derived key as a `Data` object.
+    public func deriveKey(arguments: [KeyDerivationArguments]) throws -> Data {
+        guard let password = arguments.password else {
             throw CryptoError.missingArguments(["password"])
         }
-        guard
-            let salt = arguments.saltInput,
-            let count = arguments.saltCount
-        else {
+        guard let salt = arguments.saltInput, let count = arguments.saltCount else {
             throw CryptoError.missingPBS2SaltInputOrCount
         }
         

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBES2SHA.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyDerivation/PBES2/PBES2SHA.swift
@@ -19,15 +19,28 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PBES2SHAKeyDerivation` provides methods to derive keys using the PBES2-HMAC-SHA algorithm.
 struct PBES2SHAKeyDerivation {
     
-    struct PBES2SHAResult {
+    /// `PBES2SHAResult` represents the result of the PBES2-HMAC-SHA key derivation process.
+    public struct PBES2SHAResult {
+        /// The derived key.
         let derivedKey: Data
+        /// The salt input used in the derivation.
         let input: Data
+        /// The iteration count used in the derivation.
         let count: Int
     }
     
-    static func derive(
+    /// Derives a key using the PBES2-HMAC-SHA algorithm with the specified parameters.
+    /// - Parameters:
+    ///   - password: The password to use for key derivation.
+    ///   - saltInput: The salt input to use for key derivation.
+    ///   - saltCount: The iteration count to use for key derivation.
+    ///   - variant: The HMAC variant to use for key derivation.
+    /// - Throws: An error if the key derivation fails or if the HMAC variant is unavailable.
+    /// - Returns: A `PBES2SHAResult` object containing the derived key, salt input, and iteration count.
+    public static func derive(
         password: Data,
         saltInput: Data,
         saltCount: Int,

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AES128GCM+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AES128GCM+KeyEncryption.swift
@@ -18,15 +18,22 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `AES128GCM` conform to `KeyWrapping`.
 extension AES128GCM: KeyWrapping {
-    func contentKeyEncrypt(
+    
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if required arguments are missing or if the encryption fails.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key, initialization vector, authentication tag, and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
     ) throws -> KeyEncriptionResultMetadata {
-        guard
-            let key = using.key
-        else {
+        guard let key = using.key else {
             throw CryptoError.missingArguments([])
         }
 

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AES192GCM+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AES192GCM+KeyEncryption.swift
@@ -18,15 +18,22 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `AES192GCM` conform to `KeyWrapping`.
 extension AES192GCM: KeyWrapping {
-    func contentKeyEncrypt(
+    
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if required arguments are missing or if the encryption fails.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key, initialization vector, authentication tag, and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
     ) throws -> KeyEncriptionResultMetadata {
-        guard
-            let key = using.key
-        else {
+        guard let key = using.key else {
             throw CryptoError.missingArguments([])
         }
 

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AES256GCM+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AES256GCM+KeyEncryption.swift
@@ -18,15 +18,22 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `AES256GCM` conform to `KeyWrapping`.
 extension AES256GCM: KeyWrapping {
-    func contentKeyEncrypt(
+    
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if required arguments are missing or if the encryption fails.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key, initialization vector, authentication tag, and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
     ) throws -> KeyEncriptionResultMetadata {
-        guard
-            let key = using.key
-        else {
+        guard let key = using.key else {
             throw CryptoError.missingArguments([])
         }
 

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AESGCM+KeyUnwrap.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AESGCM+KeyUnwrap.swift
@@ -18,8 +18,17 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// Extension to make `AESGCM` conform to `KeyUnwrapping`.
 extension AESGCM: KeyUnwrapping {
-    func contentKeyDecrypt(
+    
+    /// Decrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - encryptedKey: The encrypted content encryption key to be decrypted.
+    ///   - using: The `JWK` to use for decryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key decryption.
+    /// - Throws: An error if required arguments are missing or if the decryption fails.
+    /// - Returns: The decrypted key as a `Data` object.
+    public func contentKeyDecrypt(
         encryptedKey: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AESKeyUnwrap+KeyUnwrap.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AESKeyUnwrap+KeyUnwrap.swift
@@ -19,8 +19,17 @@ import Foundation
 import JSONWebKey
 import Tools
 
+/// `AESKeyUnwrap` provides methods to decrypt content encryption keys (CEKs) using AES key unwrapping.
 struct AESKeyUnwrap: KeyUnwrapping {
-    func contentKeyDecrypt(
+    
+    /// Decrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - encryptedKey: The encrypted content encryption key to be decrypted.
+    ///   - using: The `JWK` to use for decryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key decryption.
+    /// - Throws: An error if the decryption fails or if the required key is missing.
+    /// - Returns: The decrypted key as a `Data` object.
+    public func contentKeyDecrypt(
         encryptedKey: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AESKeyWrap+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/AES/AESKeyWrap+KeyEncryption.swift
@@ -19,12 +19,24 @@ import Foundation
 import JSONWebKey
 import Tools
 
+/// `AESKeyWrap` provides methods to encrypt content encryption keys (CEKs) using AES key wrapping.
 struct AESKeyWrap: KeyWrapping {
-    func generateInitializationVector() throws -> Data {
+    
+    /// Generates an initialization vector.
+    /// - Throws: An error if the generation fails.
+    /// - Returns: An empty `Data` object as no initialization vector is required for AES key wrapping.
+    public func generateInitializationVector() throws -> Data {
         Data()
     }
     
-    func contentKeyEncrypt(
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if the encryption fails or if the required key is missing.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSA15KeyUnwrap+KeyUnwrapping.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSA15KeyUnwrap+KeyUnwrapping.swift
@@ -19,8 +19,17 @@ import Foundation
 import JSONWebKey
 import Security
 
-struct RSA15KeyUnwrap: KeyUnwrapping {
-    func contentKeyDecrypt(
+/// `RSA15KeyUnwrap` provides methods to decrypt content encryption keys (CEKs) using RSAES-PKCS1-v1_5.
+public struct RSA15KeyUnwrap: KeyUnwrapping {
+    
+    /// Decrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - encryptedKey: The encrypted content encryption key to be decrypted.
+    ///   - using: The `JWK` to use for decryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key decryption.
+    /// - Throws: An error if the decryption fails or if required components are missing from the JWK.
+    /// - Returns: The decrypted key as a `Data` object.
+    public func contentKeyDecrypt(
         encryptedKey: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
@@ -34,10 +43,7 @@ struct RSA15KeyUnwrap: KeyUnwrapping {
         guard let d = using.d else {
             throw JWK.Error.missingDComponent
         }
-        guard
-            let p = using.p,
-            let q = using.q
-        else {
+        guard let p = using.p, let q = using.q else {
             throw JWK.Error.missingPrimesComponent
         }
         
@@ -65,14 +71,12 @@ struct RSA15KeyUnwrap: KeyUnwrapping {
         }
         let secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionPKCS1
         var decryptionError: Unmanaged<CFError>?
-        guard
-            let plaintext = SecKeyCreateDecryptedData(
-                rsaSecKey,
-                secKeyAlgorithm,
-                encryptedKey as CFData,
-                &decryptionError
-            )
-        else {
+        guard let plaintext = SecKeyCreateDecryptedData(
+            rsaSecKey,
+            secKeyAlgorithm,
+            encryptedKey as CFData,
+            &decryptionError
+        ) else {
             throw CryptoError.securityLayerError(internalStatus: nil, internalError: decryptionError?.takeRetainedValue())
         }
         return plaintext as Data

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSA15KeyWrapper+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSA15KeyWrapper+KeyEncryption.swift
@@ -19,12 +19,24 @@ import Foundation
 import JSONWebKey
 import Security
 
-struct RSA15KeyWrapper: KeyWrapping {
-    func generateInitializationVector() throws -> Data {
+/// `RSA15KeyWrapper` provides methods to encrypt content encryption keys (CEKs) using RSAES-PKCS1-v1_5.
+public struct RSA15KeyWrapper: KeyWrapping {
+    
+    /// Generates an initialization vector.
+    /// - Throws: An error if the generation fails.
+    /// - Returns: An empty `Data` object as no initialization vector is required for RSA key wrapping.
+    public func generateInitializationVector() throws -> Data {
         Data()
     }
     
-    func contentKeyEncrypt(
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if the encryption fails or if the required components are missing from the JWK.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
@@ -51,16 +63,14 @@ struct RSA15KeyWrapper: KeyWrapping {
         ) else {
             throw CryptoError.invalidRSAKey
         }
-        var secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionPKCS1
+        let secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionPKCS1
         var encryptionError: Unmanaged<CFError>?
-        guard
-            let ciphertext = SecKeyCreateEncryptedData(
-                rsaSecKey,
-                secKeyAlgorithm,
-                cek as CFData,
-                &encryptionError
-            )
-        else {
+        guard let ciphertext = SecKeyCreateEncryptedData(
+            rsaSecKey,
+            secKeyAlgorithm,
+            cek as CFData,
+            &encryptionError
+        ) else {
             throw CryptoError.securityLayerError(internalStatus: nil, internalError: encryptionError?.takeRetainedValue())
         }
         return .init(encryptedKey: ciphertext as Data)

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEP256KeyUnwrap+KeyUnwrapping.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEP256KeyUnwrap+KeyUnwrapping.swift
@@ -19,8 +19,17 @@ import Foundation
 import JSONWebKey
 import Security
 
-struct RSAOAEP256KeyUnwrap: KeyUnwrapping {
-    func contentKeyDecrypt(
+/// `RSAOAEP256KeyUnwrap` provides methods to decrypt content encryption keys (CEKs) using RSAES-OAEP with SHA-256.
+public struct RSAOAEP256KeyUnwrap: KeyUnwrapping {
+    
+    /// Decrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - encryptedKey: The encrypted content encryption key to be decrypted.
+    ///   - using: The `JWK` to use for decryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key decryption.
+    /// - Throws: An error if the decryption fails or if required components are missing from the JWK.
+    /// - Returns: The decrypted key as a `Data` object.
+    public func contentKeyDecrypt(
         encryptedKey: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
@@ -34,10 +43,7 @@ struct RSAOAEP256KeyUnwrap: KeyUnwrapping {
         guard let d = using.d else {
             throw JWK.Error.missingDComponent
         }
-        guard
-            let p = using.p,
-            let q = using.q
-        else {
+        guard let p = using.p, let q = using.q else {
             throw JWK.Error.missingPrimesComponent
         }
         
@@ -65,14 +71,12 @@ struct RSAOAEP256KeyUnwrap: KeyUnwrapping {
         }
         let secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionOAEPSHA256
         var decryptionError: Unmanaged<CFError>?
-        guard
-            let plaintext = SecKeyCreateDecryptedData(
-                rsaSecKey,
-                secKeyAlgorithm,
-                encryptedKey as CFData,
-                &decryptionError
-            )
-        else {
+        guard let plaintext = SecKeyCreateDecryptedData(
+            rsaSecKey,
+            secKeyAlgorithm,
+            encryptedKey as CFData,
+            &decryptionError
+        ) else {
             throw CryptoError.failedRSAKeyUnwrap
         }
         return plaintext as Data

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEP256KeyWrap+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEP256KeyWrap+KeyEncryption.swift
@@ -19,12 +19,24 @@ import Foundation
 import JSONWebKey
 import Security
 
-struct RSAOAEP256KeyWrapper: KeyWrapping {
-    func generateInitializationVector() throws -> Data {
+/// `RSAOAEP256KeyWrapper` provides methods to encrypt content encryption keys (CEKs) using RSAES-OAEP with SHA-256.
+public struct RSAOAEP256KeyWrapper: KeyWrapping {
+    
+    /// Generates an initialization vector.
+    /// - Throws: An error if the generation fails.
+    /// - Returns: An empty `Data` object as no initialization vector is required for RSA key wrapping.
+    public func generateInitializationVector() throws -> Data {
         Data()
     }
     
-    func contentKeyEncrypt(
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if the encryption fails or if the required components are missing from the JWK.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
@@ -51,16 +63,14 @@ struct RSAOAEP256KeyWrapper: KeyWrapping {
         ) else {
             throw CryptoError.invalidRSAKey
         }
-        var secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionOAEPSHA256
+        let secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionOAEPSHA256
         var encryptionError: Unmanaged<CFError>?
-        guard
-            let ciphertext = SecKeyCreateEncryptedData(
-                rsaSecKey,
-                secKeyAlgorithm,
-                cek as CFData,
-                &encryptionError
-            )
-        else {
+        guard let ciphertext = SecKeyCreateEncryptedData(
+            rsaSecKey,
+            secKeyAlgorithm,
+            cek as CFData,
+            &encryptionError
+        ) else {
             throw CryptoError.securityLayerError(internalStatus: nil, internalError: encryptionError?.takeRetainedValue())
         }
         return .init(encryptedKey: ciphertext as Data)

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEPKeyUnwrap+KeyUnwrapping.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEPKeyUnwrap+KeyUnwrapping.swift
@@ -19,8 +19,17 @@ import Foundation
 import JSONWebKey
 import Security
 
-struct RSAOAEPKeyUnwrap: KeyUnwrapping {
-    func contentKeyDecrypt(
+/// `RSAOAEPKeyUnwrap` provides methods to decrypt content encryption keys (CEKs) using RSAES-OAEP with SHA-1.
+public struct RSAOAEPKeyUnwrap: KeyUnwrapping {
+    
+    /// Decrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - encryptedKey: The encrypted content encryption key to be decrypted.
+    ///   - using: The `JWK` to use for decryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key decryption.
+    /// - Throws: An error if the decryption fails or if required components are missing from the JWK.
+    /// - Returns: The decrypted key as a `Data` object.
+    public func contentKeyDecrypt(
         encryptedKey: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
@@ -34,10 +43,7 @@ struct RSAOAEPKeyUnwrap: KeyUnwrapping {
         guard let d = using.d else {
             throw JWK.Error.missingDComponent
         }
-        guard
-            let p = using.p,
-            let q = using.q
-        else {
+        guard let p = using.p, let q = using.q else {
             throw JWK.Error.missingPrimesComponent
         }
         
@@ -65,14 +71,12 @@ struct RSAOAEPKeyUnwrap: KeyUnwrapping {
         }
         let secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionOAEPSHA1
         var decryptionError: Unmanaged<CFError>?
-        guard
-            let plaintext = SecKeyCreateDecryptedData(
-                rsaSecKey,
-                secKeyAlgorithm,
-                encryptedKey as CFData,
-                &decryptionError
-            )
-        else {
+        guard let plaintext = SecKeyCreateDecryptedData(
+            rsaSecKey,
+            secKeyAlgorithm,
+            encryptedKey as CFData,
+            &decryptionError
+        ) else {
             throw CryptoError.failedRSAKeyUnwrap
         }
         return plaintext as Data

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEPKeyWrap+KeyEncryption.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyEncryption/RSA/RSAOAEPKeyWrap+KeyEncryption.swift
@@ -19,12 +19,24 @@ import Foundation
 import JSONWebKey
 import Security
 
-struct RSAOAEPKeyWrapper: KeyWrapping {
-    func generateInitializationVector() throws -> Data {
+/// `RSAOAEPKeyWrapper` provides methods to encrypt content encryption keys (CEKs) using RSAES-OAEP with SHA-1.
+public struct RSAOAEPKeyWrapper: KeyWrapping {
+    
+    /// Generates an initialization vector.
+    /// - Throws: An error if the generation fails.
+    /// - Returns: An empty `Data` object as no initialization vector is required for RSA key wrapping.
+    public func generateInitializationVector() throws -> Data {
         Data()
     }
     
-    func contentKeyEncrypt(
+    /// Encrypts the content encryption key (CEK) using the provided JWK and key encryption arguments.
+    /// - Parameters:
+    ///   - cek: The content encryption key to be encrypted.
+    ///   - using: The `JWK` to use for encryption.
+    ///   - arguments: An array of `KeyEncryptionArguments` containing the necessary parameters for key encryption.
+    /// - Throws: An error if the encryption fails or if the required components are missing from the JWK.
+    /// - Returns: A `KeyEncriptionResultMetadata` object containing the encrypted key and other metadata.
+    public func contentKeyEncrypt(
         cek: Data,
         using: JWK,
         arguments: [KeyEncryptionArguments]
@@ -51,16 +63,14 @@ struct RSAOAEPKeyWrapper: KeyWrapping {
         ) else {
             throw CryptoError.invalidRSAKey
         }
-        var secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionOAEPSHA1
+        let secKeyAlgorithm = SecKeyAlgorithm.rsaEncryptionOAEPSHA1
         var encryptionError: Unmanaged<CFError>?
-        guard
-            let ciphertext = SecKeyCreateEncryptedData(
-                rsaSecKey,
-                secKeyAlgorithm,
-                cek as CFData,
-                &encryptionError
-            )
-        else {
+        guard let ciphertext = SecKeyCreateEncryptedData(
+            rsaSecKey,
+            secKeyAlgorithm,
+            cek as CFData,
+            &encryptionError
+        ) else {
             throw CryptoError.securityLayerError(internalStatus: nil, internalError: encryptionError?.takeRetainedValue())
         }
         return .init(encryptedKey: ciphertext as Data)

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyRepresentable.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyRepresentable.swift
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CryptoSwift
+import CryptoKit
+import Foundation
+import JSONWebKey
+import secp256k1
+
+extension JWK {
+    public enum KeyFormat {
+        case rsa
+        case curve25519
+        case p256
+        case p384
+        case p512
+        case secp256k1
+        case octSequence
+    }
+    
+    public static func JWKFrom<Key>(format: KeyFormat, isPrivate: Bool, isKeyAgreement: Bool, key: Key) throws -> JWK {
+        switch key {
+        case let value as Data:
+            return try getJWKFromData(format: format, isPrivate: isPrivate, isKeyAgreement: isKeyAgreement, value: value)
+        case let value as SecKey:
+            return try getJWKFromSecKey(format: format, isPrivate: isPrivate, isKeyAgreement: isKeyAgreement, value: value)
+        case let value as JWK:
+            return value
+        default:
+            throw isPrivate ? CryptoError.notValidPrivateKey : CryptoError.notValidPublicKey
+        }
+    }
+}
+
+private func getJWKFromData(format: JWK.KeyFormat, isPrivate: Bool, isKeyAgreement: Bool, value: Data) throws -> JWK {
+    switch format {
+    case .rsa:
+        let rsaKey = try CryptoSwift.RSA(rawRepresentation: value)
+        let n = rsaKey.n.serialize()
+        let e = rsaKey.e.serialize()
+        let d = rsaKey.d?.serialize()
+        
+        return JWK(keyType: .rsa, e: e, n: n, d: d)
+    case .curve25519 where isKeyAgreement == false:
+        if isPrivate {
+            return try Curve25519.Signing.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try Curve25519.Signing.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .curve25519 where isKeyAgreement == true:
+        if isPrivate {
+            return try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try Curve25519.KeyAgreement.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .p256 where isKeyAgreement == false:
+        if isPrivate {
+            return try P256.Signing.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try P256.Signing.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .p256 where isKeyAgreement == true:
+        if isPrivate {
+            return try P256.KeyAgreement.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try P256.KeyAgreement.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .p384 where isKeyAgreement == false:
+        if isPrivate {
+            return try P384.Signing.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try P384.Signing.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .p384 where isKeyAgreement == true:
+        if isPrivate {
+            return try P384.KeyAgreement.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try P384.KeyAgreement.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .p512 where isKeyAgreement == false:
+        if isPrivate {
+            return try P521.Signing.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try P521.Signing.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .p512 where isKeyAgreement == true:
+        if isPrivate {
+            return try P521.KeyAgreement.PrivateKey(rawRepresentation: value).jwkRepresentation
+        } else {
+            return try P521.KeyAgreement.PublicKey(rawRepresentation: value).jwkRepresentation
+        }
+    case .secp256k1 where isKeyAgreement == false:
+        if isPrivate {
+            return try secp256k1.Signing.PrivateKey(dataRepresentation: value).jwkRepresentation
+        } else {
+            return try secp256k1.Signing.PublicKey(dataRepresentation: value, format: .uncompressed).jwkRepresentation
+        }
+    case .secp256k1 where isKeyAgreement == true:
+        if isPrivate {
+            return try secp256k1.KeyAgreement.PrivateKey(dataRepresentation: value).jwkRepresentation
+        } else {
+            return try secp256k1.KeyAgreement.PublicKey(dataRepresentation: value, format: .uncompressed).jwkRepresentation
+        }
+    case .octSequence:
+        return JWK(keyType: .octetSequence, key: value)
+    default:
+        throw isPrivate ? CryptoError.notValidPrivateKey : CryptoError.notValidPublicKey
+    }
+}
+
+private func getJWKFromSecKey(format: JWK.KeyFormat, isPrivate: Bool, isKeyAgreement: Bool, value: SecKey) throws -> JWK {
+    let data = try convertSecKeyToData(value)
+    return try getJWKFromData(format: format, isPrivate: isPrivate, isKeyAgreement: isKeyAgreement, value: data)
+}
+
+private func convertSecKeyToData(_ secKey: SecKey) throws -> Data {
+    var error: Unmanaged<CFError>?
+    guard let keyData = SecKeyCopyExternalRepresentation(secKey, &error) else {
+        throw CryptoError.securityLayerError(internalStatus: nil, internalError: error?.takeRetainedValue())
+    }
+
+    return keyData as Data
+}

--- a/Sources/JSONWebAlgorithms/Signatures/Curve25519/EdDSASigner.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/Curve25519/EdDSASigner.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `EdDSASigner` provides methods to sign data using the EdDSA algorithm.
 public struct EdDSASigner: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.EdDSA.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let d = key.d else { throw CryptoError.notValidPrivateKey }
         let privateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: d)

--- a/Sources/JSONWebAlgorithms/Signatures/Curve25519/EdDSAVerifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/Curve25519/EdDSAVerifier.swift
@@ -18,13 +18,21 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `EdDSAVerifier` provides methods to verify signatures using the EdDSA algorithm.
 public struct EdDSAVerifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.EdDSA.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let x = key?.x
-        else { throw CryptoError.notValidPublicKey }
+        guard let x = key?.x else { throw CryptoError.notValidPublicKey }
         let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: x)
         return publicKey.isValidSignature(signature, for: data)
     }

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES256KSigner.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES256KSigner.swift
@@ -18,17 +18,31 @@ import Foundation
 import JSONWebKey
 import secp256k1
 
+/// `ES256KSigner` provides methods to sign data using the ES256K algorithm.
 public struct ES256KSigner: Signer {
+    
+    /// Enum representing the signature format.
     public enum SignatureFormat {
+        /// Raw format.
         case raw
+        /// DER format.
         case der
     }
     
+    /// The output format of the signature.
     public static var outputFormat = ES256KSigner.SignatureFormat.raw
+    /// Indicates whether the bytes R and S are inverted.
     public static var invertedBytesR_S = false
     
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.ES256K.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let d = key.d else { throw CryptoError.notValidPrivateKey }
         let privateKey = try secp256k1.Signing.PrivateKey(dataRepresentation: d)

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES256Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES256Signer.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `ES256Signer` provides methods to sign data using the ES256 algorithm.
 public struct ES256Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.ES256.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let d = key.d else { throw CryptoError.notValidPrivateKey }
         let privateKey = try P256.Signing.PrivateKey(rawRepresentation: d)

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES384Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES384Signer.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `ES384Signer` provides methods to sign data using the ES384 algorithm.
 public struct ES384Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.ES384.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let d = key.d else { throw CryptoError.notValidPrivateKey }
         let privateKey = try P384.Signing.PrivateKey(rawRepresentation: d)

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES521Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Signers/ES521Signer.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `ES512Signer` provides methods to sign data using the ES512 algorithm.
 public struct ES512Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.ES512.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let d = key.d else { throw CryptoError.notValidPrivateKey }
         let privateKey = try P521.Signing.PrivateKey(rawRepresentation: d)

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES256KVerifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES256KVerifier.swift
@@ -18,16 +18,24 @@ import Foundation
 import JSONWebKey
 import secp256k1
 
+/// `ES256KVerifier` provides methods to verify signatures using the ES256K algorithm.
 public struct ES256KVerifier: Verifier {
+    
+    /// Indicates whether to use a fail-safe mechanism compatible with Bouncy Castle.
     public static var bouncyCastleFailSafe = false
     
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.ES256K.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let x = key?.x,
-            let y = key?.y
-        else { throw CryptoError.notValidPublicKey }
+        guard let x = key?.x, let y = key?.y else { throw CryptoError.notValidPublicKey }
         let publicKey = try secp256k1.Signing.PublicKey(dataRepresentation: [0x04] + x + y, format: .uncompressed)
         let hash = SHA256.hash(data: data)
         let objSignature = try getSignature(signature).normalize

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES256Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES256Verifier.swift
@@ -18,14 +18,21 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `ES256Verifier` provides methods to verify signatures using the ES256 algorithm.
 public struct ES256Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.ES256.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let x = key?.x,
-            let y = key?.y
-        else { throw CryptoError.notValidPublicKey }
+        guard let x = key?.x, let y = key?.y else { throw CryptoError.notValidPublicKey }
         let publicKey = try P256.Signing.PublicKey(rawRepresentation: x + y)
         let hash = SHA256.hash(data: data)
         return try publicKey.isValidSignature(getSignature(signature), for: hash)

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES384Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES384Verifier.swift
@@ -18,14 +18,21 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `ES384Verifier` provides methods to verify signatures using the ES384 algorithm.
 public struct ES384Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.ES384.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let x = key?.x,
-            let y = key?.y
-        else { throw CryptoError.notValidPublicKey }
+        guard let x = key?.x, let y = key?.y else { throw CryptoError.notValidPublicKey }
         let publicKey = try P384.Signing.PublicKey(rawRepresentation: x + y)
         let hash = SHA384.hash(data: data)
         return publicKey.isValidSignature(try getSignature(signature), for: hash)

--- a/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES521Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/EC/Verifiers/ES521Verifier.swift
@@ -18,14 +18,21 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `ES521Verifier` provides methods to verify signatures using the ES521 algorithm.
 public struct ES521Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.ES512.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let x = key?.x,
-            let y = key?.y
-        else { throw CryptoError.notValidPublicKey }
+        guard let x = key?.x, let y = key?.y else { throw CryptoError.notValidPublicKey }
         let publicKey = try P521.Signing.PublicKey(rawRepresentation: x + y)
         let hash = SHA512.hash(data: data)
         return try publicKey.isValidSignature(getSignature(signature), for: hash)

--- a/Sources/JSONWebAlgorithms/Signatures/HMAC/Signers/HS256Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/HMAC/Signers/HS256Signer.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `HS256Signer` provides methods to sign data using the HS256 algorithm.
 public struct HS256Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.HS256.rawValue }
     
+    /// Signs the given data using the provided symmetric key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the symmetric key to use for signing.
+    /// - Throws: An error if the symmetric key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let k = key.key else { throw CryptoError.notValidPrivateKey }
         let symmetryKey = SymmetricKey(data: k)

--- a/Sources/JSONWebAlgorithms/Signatures/HMAC/Signers/HS384Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/HMAC/Signers/HS384Signer.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `HS384Signer` provides methods to sign data using the HS384 algorithm.
 public struct HS384Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.HS384.rawValue }
     
+    /// Signs the given data using the provided symmetric key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the symmetric key to use for signing.
+    /// - Throws: An error if the symmetric key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let k = key.key else { throw CryptoError.notValidPrivateKey }
         let symmetryKey = SymmetricKey(data: k)

--- a/Sources/JSONWebAlgorithms/Signatures/HMAC/Signers/HS512Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/HMAC/Signers/HS512Signer.swift
@@ -18,9 +18,18 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `HS512Signer` provides methods to sign data using the HS512 algorithm.
 public struct HS512Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.HS512.rawValue }
     
+    /// Signs the given data using the provided symmetric key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the symmetric key to use for signing.
+    /// - Throws: An error if the symmetric key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard let k = key.key else { throw CryptoError.notValidPrivateKey }
         let symmetryKey = SymmetricKey(data: k)

--- a/Sources/JSONWebAlgorithms/Signatures/HMAC/Verifiers/HS256Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/HMAC/Verifiers/HS256Verifier.swift
@@ -18,9 +18,19 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `HS256Verifier` provides methods to verify signatures using the HS256 algorithm.
 public struct HS256Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.HS256.rawValue }
     
+    /// Verifies the given data and signature using the provided symmetric key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the symmetric key to use for verification.
+    /// - Throws: An error if the symmetric key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
         guard let k = key?.key else { throw CryptoError.notValidPrivateKey }
         let symmetryKey = SymmetricKey(data: k)

--- a/Sources/JSONWebAlgorithms/Signatures/HMAC/Verifiers/HS384Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/HMAC/Verifiers/HS384Verifier.swift
@@ -18,9 +18,19 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `HS384Verifier` provides methods to verify signatures using the HS384 algorithm.
 public struct HS384Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.HS384.rawValue }
     
+    /// Verifies the given data and signature using the provided symmetric key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the symmetric key to use for verification.
+    /// - Throws: An error if the symmetric key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
         guard let k = key?.key else { throw CryptoError.notValidPrivateKey }
         let symmetryKey = SymmetricKey(data: k)

--- a/Sources/JSONWebAlgorithms/Signatures/HMAC/Verifiers/HS512Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/HMAC/Verifiers/HS512Verifier.swift
@@ -18,9 +18,19 @@ import CryptoKit
 import Foundation
 import JSONWebKey
 
+/// `HS512Verifier` provides methods to verify signatures using the HS512 algorithm.
 public struct HS512Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.HS512.rawValue }
     
+    /// Verifies the given data and signature using the provided symmetric key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the symmetric key to use for verification.
+    /// - Throws: An error if the symmetric key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
         guard let k = key?.key else { throw CryptoError.notValidPrivateKey }
         let symmetryKey = SymmetricKey(data: k)

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/PS256Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/PS256Signer.swift
@@ -18,23 +18,25 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PS256Signer` provides methods to sign data using the PS256 algorithm.
 public struct PS256Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.PS256.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
-        guard
-            let n = key.n,
-            let e = key.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key.n, let e = key.e else { throw CryptoError.notValidPrivateKey }
         let privateKey: RSA
-        if
-            let p = key.p,
-            let q = key.q,
-            let d = key.d
-        {
+        if let p = key.p, let q = key.q, let d = key.d {
             privateKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map {BigUInteger($0)})
+            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map { BigUInteger($0) })
         }
         
         let secKey = try privateKey.getSecKey()

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/PS384Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/PS384Signer.swift
@@ -18,23 +18,25 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PS384Signer` provides methods to sign data using the PS384 algorithm.
 public struct PS384Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.PS384.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
-        guard
-            let n = key.n,
-            let e = key.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key.n, let e = key.e else { throw CryptoError.notValidPrivateKey }
         let privateKey: RSA
-        if
-            let p = key.p,
-            let q = key.q,
-            let d = key.d
-        {
+        if let p = key.p, let q = key.q, let d = key.d {
             privateKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map {BigUInteger($0)})
+            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map { BigUInteger($0) })
         }
         
         let secKey = try privateKey.getSecKey()

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/PS512Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/PS512Signer.swift
@@ -18,23 +18,25 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PS512Signer` provides methods to sign data using the PS512 algorithm.
 public struct PS512Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.PS512.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
-        guard
-            let n = key.n,
-            let e = key.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key.n, let e = key.e else { throw CryptoError.notValidPrivateKey }
         let privateKey: RSA
-        if
-            let p = key.p,
-            let q = key.q,
-            let d = key.d
-        {
+        if let p = key.p, let q = key.q, let d = key.d {
             privateKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map {BigUInteger($0)})
+            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map { BigUInteger($0) })
         }
         
         let secKey = try privateKey.getSecKey()

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/RS256Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/RS256Signer.swift
@@ -18,9 +18,18 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `RS256Signer` provides methods to sign data using the RS256 algorithm.
 public struct RS256Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.RS256.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
         guard
             let n = key.n,

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/RS384Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/RS384Signer.swift
@@ -18,23 +18,25 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `RS384Signer` provides methods to sign data using the RS384 algorithm.
 public struct RS384Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.RS384.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
-        guard
-            let n = key.n,
-            let e = key.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key.n, let e = key.e else { throw CryptoError.notValidPrivateKey }
         let privateKey: RSA
-        if
-            let p = key.p,
-            let q = key.q,
-            let d = key.d
-        {
+        if let p = key.p, let q = key.q, let d = key.d {
             privateKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map {BigUInteger($0)})
+            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map { BigUInteger($0) })
         }
         
         return try Data(privateKey.sign(data.bytes, variant: .message_pkcs1v15_SHA384))

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/RS512Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Signers/RS512Signer.swift
@@ -18,23 +18,25 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `RS512Signer` provides methods to sign data using the RS512 algorithm.
 public struct RS512Signer: Signer {
+    
+    /// The algorithm used for signing.
     public var algorithm: String { SigningAlgorithm.RS512.rawValue }
     
+    /// Signs the given data using the provided private key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the private key to use for signing.
+    /// - Throws: An error if the private key is not valid or if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     public func sign(data: Data, key: JWK) throws -> Data {
-        guard
-            let n = key.n,
-            let e = key.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key.n, let e = key.e else { throw CryptoError.notValidPrivateKey }
         let privateKey: RSA
-        if
-            let p = key.p,
-            let q = key.q,
-            let d = key.d
-        {
+        if let p = key.p, let q = key.q, let d = key.d {
             privateKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map {BigUInteger($0)})
+            privateKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key.d.map { BigUInteger($0) })
         }
         
         return try Data(privateKey.sign(data.bytes, variant: .message_pkcs1v15_SHA512))

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/PS256Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/PS256Verifier.swift
@@ -18,23 +18,26 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PS256Verifier` provides methods to verify signatures using the PS256 algorithm.
 public struct PS256Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.PS256.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let n = key?.n,
-            let e = key?.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key?.n, let e = key?.e else { throw CryptoError.notValidPrivateKey }
         let publicKey: RSA
-        if
-            let p = key?.p,
-            let q = key?.q,
-            let d = key?.d
-        {
+        if let p = key?.p, let q = key?.q, let d = key?.d {
             publicKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map {BigUInteger($0)})
+            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map { BigUInteger($0) })
         }
         
         let secKey = try publicKey.getSecKey()

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/PS384Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/PS384Verifier.swift
@@ -18,23 +18,26 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PS384Verifier` provides methods to verify signatures using the PS384 algorithm.
 public struct PS384Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.PS384.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let n = key?.n,
-            let e = key?.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key?.n, let e = key?.e else { throw CryptoError.notValidPrivateKey }
         let publicKey: RSA
-        if
-            let p = key?.p,
-            let q = key?.q,
-            let d = key?.d
-        {
+        if let p = key?.p, let q = key?.q, let d = key?.d {
             publicKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map {BigUInteger($0)})
+            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map { BigUInteger($0) })
         }
         
         let secKey = try publicKey.getSecKey()

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/PS512Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/PS512Verifier.swift
@@ -18,23 +18,26 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `PS512Verifier` provides methods to verify signatures using the PS512 algorithm.
 public struct PS512Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.PS512.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let n = key?.n,
-            let e = key?.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key?.n, let e = key?.e else { throw CryptoError.notValidPrivateKey }
         let publicKey: RSA
-        if
-            let p = key?.p,
-            let q = key?.q,
-            let d = key?.d
-        {
+        if let p = key?.p, let q = key?.q, let d = key?.d {
             publicKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map {BigUInteger($0)})
+            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map { BigUInteger($0) })
         }
         
         let secKey = try publicKey.getSecKey()

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/RS256Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/RS256Verifier.swift
@@ -18,23 +18,26 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `RS256Verifier` provides methods to verify signatures using the RS256 algorithm.
 public struct RS256Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.RS256.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let n = key?.n,
-            let e = key?.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key?.n, let e = key?.e else { throw CryptoError.notValidPrivateKey }
         let publicKey: RSA
-        if
-            let p = key?.p,
-            let q = key?.q,
-            let d = key?.d
-        {
+        if let p = key?.p, let q = key?.q, let d = key?.d {
             publicKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map {BigUInteger($0)})
+            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map { BigUInteger($0) })
         }
         
         return try publicKey.verify(signature: signature.bytes, for: data.bytes, variant: .message_pkcs1v15_SHA256)

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/RS384Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/RS384Verifier.swift
@@ -18,23 +18,26 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `RS384Verifier` provides methods to verify signatures using the RS384 algorithm.
 public struct RS384Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.RS384.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let n = key?.n,
-            let e = key?.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key?.n, let e = key?.e else { throw CryptoError.notValidPrivateKey }
         let publicKey: RSA
-        if
-            let p = key?.p,
-            let q = key?.q,
-            let d = key?.d
-        {
+        if let p = key?.p, let q = key?.q, let d = key?.d {
             publicKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map {BigUInteger($0)})
+            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map { BigUInteger($0) })
         }
         
         return try publicKey.verify(signature: signature.bytes, for: data.bytes, variant: .message_pkcs1v15_SHA384)

--- a/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/RS512Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/RSA/Verifiers/RS512Verifier.swift
@@ -18,23 +18,26 @@ import CryptoSwift
 import Foundation
 import JSONWebKey
 
+/// `RS512Verifier` provides methods to verify signatures using the RS512 algorithm.
 public struct RS512Verifier: Verifier {
+    
+    /// The algorithm used for verification.
     public var algorithm: String { SigningAlgorithm.RS512.rawValue }
     
+    /// Verifies the given data and signature using the provided public key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the public key to use for verification.
+    /// - Throws: An error if the public key is not valid or if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     public func verify(data: Data, signature: Data, key: JWK?) throws -> Bool {
-        guard
-            let n = key?.n,
-            let e = key?.e
-        else { throw CryptoError.notValidPrivateKey }
+        guard let n = key?.n, let e = key?.e else { throw CryptoError.notValidPrivateKey }
         let publicKey: RSA
-        if
-            let p = key?.p,
-            let q = key?.q,
-            let d = key?.d
-        {
+        if let p = key?.p, let q = key?.q, let d = key?.d {
             publicKey = try RSA(n: BigUInteger(n), e: BigUInteger(e), d: BigUInteger(d), p: BigUInteger(p), q: BigUInteger(q))
         } else {
-            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map {BigUInteger($0)})
+            publicKey = RSA(n: BigUInteger(n), e: BigUInteger(e), d: key?.d.map { BigUInteger($0) })
         }
         
         return try publicKey.verify(signature: signature.bytes, for: data.bytes, variant: .message_pkcs1v15_SHA512)

--- a/Sources/JSONWebAlgorithms/Signatures/Signer.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/Signer.swift
@@ -17,7 +17,17 @@
 import Foundation
 import JSONWebKey
 
+/// `Signer` defines the requirements for an object that can sign data using a specific algorithm.
 public protocol Signer {
+    
+    /// The algorithm used for signing.
     var algorithm: String { get }
+    
+    /// Signs the given data using the provided key.
+    /// - Parameters:
+    ///   - data: The data to be signed.
+    ///   - key: The `JWK` containing the key to use for signing.
+    /// - Throws: An error if the signing process fails.
+    /// - Returns: The signature as a `Data` object.
     func sign(data: Data, key: JWK) throws -> Data
 }

--- a/Sources/JSONWebAlgorithms/Signatures/Verifier.swift
+++ b/Sources/JSONWebAlgorithms/Signatures/Verifier.swift
@@ -17,7 +17,18 @@
 import Foundation
 import JSONWebKey
 
+/// `Verifier` defines the requirements for an object that can verify signatures using a specific algorithm.
 public protocol Verifier {
+    
+    /// The algorithm used for verification.
     var algorithm: String { get }
+    
+    /// Verifies the given data and signature using the provided key.
+    /// - Parameters:
+    ///   - data: The data that was signed.
+    ///   - signature: The signature to be verified.
+    ///   - key: The `JWK` containing the key to use for verification.
+    /// - Throws: An error if the verification process fails.
+    /// - Returns: A boolean value indicating whether the signature is valid.
     func verify(data: Data, signature: Data, key: JWK?) throws -> Bool
 }

--- a/Sources/JSONWebSignature/JWS+Verify.swift
+++ b/Sources/JSONWebSignature/JWS+Verify.swift
@@ -54,6 +54,47 @@ extension JWS {
         return try verifier.verify(data: signingData, signature: signature, key: key)
     }
     
+    /// Verifies the signature of the JWS using the provided key.
+    ///
+    /// This method supports different types for the `Key` parameter, including `Data`, `SecKey`, and `JWK`.
+    ///
+    /// - Parameters:
+    ///   - key: The cryptographic key used for verification, which can be of type `Data`, `SecKey`, or `JWK`.
+    ///
+    /// - Throws: An error if the verification process fails due to a missing key, unsupported algorithm, or other issues.
+    /// - Returns: A Boolean value indicating whether the signature is valid (`true`) or not (`false`).
+    public func verify<Key>(key: Key?) throws -> Bool {
+        guard SigningAlgorithm.none != protectedHeader.algorithm else {
+            return true
+        }
+        guard
+            let key,
+            let jwkKey = try prepareJWKFromHeader(header: protectedHeaderData, key: key)
+        else {
+            throw JWSError.missingKey
+        }
+        try jwkKey.algorithm.map {
+            guard $0 == protectedHeader.algorithm?.rawValue else {
+                throw JWSError.keyAlgorithmAndHeaderAlgorithmAreNotEqual(
+                    header: protectedHeader.algorithm?.rawValue ?? "",
+                    key: $0
+                )
+            }
+        }
+        
+        guard
+            let verifier = protectedHeader.algorithm?.cryptoVerifier
+        else {
+            throw JWSError.unsupportedAlgorithm(
+                keyType: protectedHeader.jwk?.keyType.rawValue,
+                algorithm: protectedHeader.algorithm?.rawValue,
+                curve: protectedHeader.jwk?.curve?.rawValue
+            )
+        }
+        let signingData = try JWS.buildSigningData(header: protectedHeaderData, data: payload)
+        return try verifier.verify(data: signingData, signature: signature, key: jwkKey)
+    }
+    
     /// Verifies the signature of a JWS JSON object using a single JSON Web Key (JWK).
     /// Can validate either all signatures or just one, depending on the `validateAll` parameter.
     ///
@@ -83,6 +124,27 @@ extension JWS {
         }
     }
     
+    /// Verifies the signature of a JSON Web Signature (JWS) object using the provided key.
+    ///
+    /// This method supports different types for the `Key` parameter, including `Data`, `SecKey`, and `JWK`.
+    ///
+    /// - Parameters:
+    ///   - jwsJson: The JSON-encoded JWS object as `Data`.
+    ///   - jwk: The cryptographic key used for verification, which can be of type `Data`, `SecKey`, or `JWK`.
+    ///
+    /// - Throws: An error if the verification process fails due to an invalid JWS format, missing key, or other issues.
+    /// - Returns: A Boolean value indicating whether at least one signature in the JWS is valid (`true`) or not (`false`).
+    public static func verify<Key>(jwsJson: Data, jwk: Key) throws -> Bool {
+        let json: JWSJson<DefaultJWSHeaderImpl, DefaultJWSHeaderImpl> = try decodeFullOrFlattenedJson(json: jwsJson)
+        guard try json.signatures
+            .map({ try $0.jws(payload: json.payload) })
+            .contains(where: { (try? $0.verify(key: jwk)) ?? false })
+        else {
+            return false
+        }
+        return true
+    }
+    
     /// Verifies the signature of a JWS JSON object using an array of JSON Web Keys (JWKs).
     /// Depending on the `allNeedToVerify` parameter, either all keys need to verify the signature successfully,
     /// or at least one key needs to succeed.
@@ -94,6 +156,25 @@ extension JWS {
     /// - Returns: `true` if the signature(s) are valid according to the provided parameters, `false` otherwise.
     /// - Throws: `JWSError` for errors encountered during verification.
     public static func verify(jwsJson: Data, jwks: [JWK], allNeedToVerify: Bool = false) throws -> Bool {
+        if allNeedToVerify {
+            return try jwks.allSatisfy { try JWS.verify(jwsJson: jwsJson, jwk: $0) }
+        } else {
+            return try jwks.contains { try JWS.verify(jwsJson: jwsJson, jwk: $0) }
+        }
+    }
+    
+    /// Verifies the signature of a JSON Web Signature (JWS) object using an array of provided keys.
+    ///
+    /// This method supports different types for the `Key` parameter, including `Data`, `SecKey`, and `JWK`.
+    ///
+    /// - Parameters:
+    ///   - jwsJson: The JSON-encoded JWS object as `Data`.
+    ///   - jwks: An array of cryptographic keys used for verification, each of which can be of type `Data`, `SecKey`, or `JWK`.
+    ///   - allNeedToVerify: A Boolean value indicating whether all signatures need to be verified (`true`) or if at least one valid signature is sufficient (`false`). Default is `false`.
+    ///
+    /// - Throws: An error if the verification process fails due to an invalid JWS format, missing key, or other issues.
+    /// - Returns: A Boolean value indicating whether the verification criteria are met. If `allNeedToVerify` is `true`, returns `true` if all signatures are valid. If `allNeedToVerify` is `false`, returns `true` if at least one signature is valid.
+    public static func verify<Key>(jwsJson: Data, jwks: [Key], allNeedToVerify: Bool = false) throws -> Bool {
         if allNeedToVerify {
             return try jwks.allSatisfy { try JWS.verify(jwsJson: jwsJson, jwk: $0) }
         } else {

--- a/Tests/JWSTests/JWSTests.swift
+++ b/Tests/JWSTests/JWSTests.swift
@@ -92,4 +92,34 @@ final class JWSTests: XCTestCase {
         XCTAssertTrue(try originalJWS.verify(key: jwk))
         XCTAssertThrowsError(try tamperedJWS.verify(key: jwk))
     }
+    
+    func testES256SigningWithDataKey() throws {
+        let keyPair = JWK.testingES256PairData
+        XCTAssertNoThrow(try JWS(payload: "test".data(using: .utf8)!, protectedHeader: DefaultJWSHeaderImpl(algorithm: .ES256), key: keyPair))
+    }
+    
+    func testES384SigningWithDataKey() throws {
+        let keyPair = JWK.testingES384PairData
+        XCTAssertNoThrow(try JWS(payload: "test".data(using: .utf8)!, protectedHeader: DefaultJWSHeaderImpl(algorithm: .ES384), key: keyPair))
+    }
+    
+    func testES512SigningWithDataKey() throws {
+        let keyPair = JWK.testingES521Pair
+        XCTAssertNoThrow(try JWS(payload: "test".data(using: .utf8)!, protectedHeader: DefaultJWSHeaderImpl(algorithm: .ES512), key: keyPair))
+    }
+    
+    func testES256KSigningWithDataKey() throws {
+        let keyPair = JWK.testingES256KPairData
+        XCTAssertNoThrow(try JWS(payload: "test".data(using: .utf8)!, protectedHeader: DefaultJWSHeaderImpl(algorithm: .ES256K), key: keyPair))
+    }
+    
+    func testEdDSASigningWithDataKey() throws {
+        let keyPair = JWK.testingCurve25519KPair
+        XCTAssertNoThrow(try JWS(payload: "test".data(using: .utf8)!, protectedHeader: DefaultJWSHeaderImpl(algorithm: .EdDSA), key: keyPair))
+    }
+    
+    func testWrongAlgKeySigningWithDataKey() throws {
+        let keyPair = JWK.testingCurve25519KPair
+        XCTAssertThrowsError(try JWS(payload: "test".data(using: .utf8)!, protectedHeader: DefaultJWSHeaderImpl(algorithm: .ES512), key: keyPair))
+    }
 }

--- a/Tests/JWSTests/Mocks/JWK+Testing.swift
+++ b/Tests/JWSTests/Mocks/JWK+Testing.swift
@@ -25,9 +25,19 @@ extension JWK {
         return privateKey.jwkRepresentation
     }
     
+    static var testingES256PairData: Data {
+        let privateKey = P256.Signing.PrivateKey()
+        return privateKey.rawRepresentation
+    }
+    
     static var testingES384Pair: JWK {
         let privateKey = P384.Signing.PrivateKey()
         return privateKey.jwkRepresentation
+    }
+    
+    static var testingES384PairData: Data {
+        let privateKey = P384.Signing.PrivateKey()
+        return privateKey.rawRepresentation
     }
     
     static var testingES521Pair: JWK {
@@ -35,13 +45,28 @@ extension JWK {
         return privateKey.jwkRepresentation
     }
     
+    static var testingES521PairData: Data {
+        let privateKey = P521.Signing.PrivateKey()
+        return privateKey.rawRepresentation
+    }
+    
     static var testingCurve25519KPair: JWK {
         let privateKey = Curve25519.Signing.PrivateKey()
         return privateKey.jwkRepresentation
     }
     
+    static var testingCurve25519PairData: Data {
+        let privateKey = Curve25519.Signing.PrivateKey()
+        return privateKey.rawRepresentation
+    }
+    
     static var testingES256KPair: JWK {
         let privateKey = try! secp256k1.Signing.PrivateKey()
         return privateKey.jwkRepresentation
+    }
+    
+    static var testingES256KPairData: Data {
+        let privateKey = try! secp256k1.Signing.PrivateKey()
+        return privateKey.dataRepresentation
     }
 }


### PR DESCRIPTION
This will enable with JWS/JWT, not to require parsing Data or SecKeys to JWT format. This in part requires that the JWS Header provides alg, and cannot be used in JWE.

- This commit also documents and makes public the JWA algorithms.