### PR TITLE
Updated x509 chain in header to be array instead of string

### DIFF
--- a/Sources/JSONWebEncryption/DefaultJWEHeaderImpl+Codable.swift
+++ b/Sources/JSONWebEncryption/DefaultJWEHeaderImpl+Codable.swift
@@ -88,7 +88,7 @@ extension DefaultJWEHeaderImpl: Codable {
         jwk = try container.decodeIfPresent(JWK.self, forKey: .jwk)
         keyID = try container.decodeIfPresent(String.self, forKey: .keyID)
         x509URL = try container.decodeIfPresent(String.self, forKey: .x509URL)
-        x509CertificateChain = try container.decodeIfPresent(String.self, forKey: .x509CertificateChain)
+        x509CertificateChain = try container.decodeIfPresent([String].self, forKey: .x509CertificateChain)
         x509CertificateSHA1Thumbprint = try container.decodeIfPresent(String.self, forKey: .x509CertificateSHA1Thumbprint)
         x509CertificateSHA256Thumbprint = try container.decodeIfPresent(String.self, forKey: .x509CertificateSHA256Thumbprint)
         ephemeralPublicKey = try container.decodeIfPresent(JWK.self, forKey: .ephemeralPublicKey)

--- a/Sources/JSONWebEncryption/JWERegisteredFieldsHeader.swift
+++ b/Sources/JSONWebEncryption/JWERegisteredFieldsHeader.swift
@@ -43,7 +43,7 @@ public protocol JWERegisteredFieldsHeader: JWARegisteredFieldsHeader {
     var x509URL: String? { get set }
 
     /// X.509 public key certificate or certificate chain in string format.
-    var x509CertificateChain: String? { get set }
+    var x509CertificateChain: [String]? { get set }
 
     /// Base64URL-encoded SHA-1 thumbprint of the DER encoding of an X.509 certificate, used for key identification.
     var x509CertificateSHA1Thumbprint: String? { get set }
@@ -87,7 +87,7 @@ public protocol JWERegisteredFieldsHeader: JWARegisteredFieldsHeader {
         jwkSetURL: String?,
         jwk: JWK?,
         x509URL: String?,
-        x509CertificateChain: String?,
+        x509CertificateChain: [String]?,
         x509CertificateSHA1Thumbprint: String?,
         x509CertificateSHA256Thumbprint: String?,
         type: String?,
@@ -113,7 +113,7 @@ extension JWERegisteredFieldsHeader {
         jwkSetURL: String? = nil,
         jwk: JWK? = nil,
         x509URL: String? = nil,
-        x509CertificateChain: String? = nil,
+        x509CertificateChain: [String]? = nil,
         x509CertificateSHA1Thumbprint: String? = nil,
         x509CertificateSHA256Thumbprint: String? = nil,
         type: String? = nil,
@@ -222,7 +222,7 @@ public struct DefaultJWEHeaderImpl: JWERegisteredFieldsHeader {
     public var jwkSetURL: String?
     public var jwk: JWK?
     public var x509URL: String?
-    public var x509CertificateChain: String?
+    public var x509CertificateChain: [String]?
     public var x509CertificateSHA1Thumbprint: String?
     public var x509CertificateSHA256Thumbprint: String?
     public var type: String?
@@ -258,7 +258,7 @@ public struct DefaultJWEHeaderImpl: JWERegisteredFieldsHeader {
         jwkSetURL: String?,
         jwk: JWK?,
         x509URL: String?,
-        x509CertificateChain: String?,
+        x509CertificateChain: [String]?,
         x509CertificateSHA1Thumbprint: String?,
         x509CertificateSHA256Thumbprint: String?,
         type: String?,

--- a/Sources/JSONWebKey/JWK+Codable.swift
+++ b/Sources/JSONWebKey/JWK+Codable.swift
@@ -74,7 +74,7 @@ extension JWK: Codable {
         }
         keyID = try container.decodeIfPresent(String.self, forKey: .keyID)
         x509URL = try container.decodeIfPresent(String.self, forKey: .x509URL)
-        x509CertificateChain = try container.decodeIfPresent(String.self, forKey: .x509CertificateChain)
+        x509CertificateChain = try container.decodeIfPresent([String].self, forKey: .x509CertificateChain)
         x509CertificateSHA1Thumbprint = try container.decodeIfPresent(String.self, forKey: .x509CertificateSHA1Thumbprint)
         x509CertificateSHA256Thumbprint = try container.decodeIfPresent(String.self, forKey: .x509CertificateSHA256Thumbprint)
         curve = try container.decodeIfPresent(JWK.CryptographicCurve.self, forKey: .curve)

--- a/Sources/JSONWebKey/JWK.swift
+++ b/Sources/JSONWebKey/JWK.swift
@@ -33,7 +33,7 @@ public struct JWK: Equatable, Hashable {
     public var x509URL: String?
 
     /// The X.509 Certificate Chain.
-    public var x509CertificateChain: String?
+    public var x509CertificateChain: [String]?
 
     /// The X.509 certificate SHA-1 thumbprint.
     public var x509CertificateSHA1Thumbprint: String?
@@ -84,7 +84,7 @@ public struct JWK: Equatable, Hashable {
         key: Data? = nil,
         keyID: String? = nil,
         x509URL: String? = nil,
-        x509CertificateChain: String? = nil,
+        x509CertificateChain: [String]? = nil,
         x509CertificateSHA1Thumbprint: String? = nil,
         x509CertificateSHA256Thumbprint: String? = nil,
         curve: CryptographicCurve? = nil,

--- a/Sources/JSONWebSignature/DefaultJWSHeaderImpl+Codable.swift
+++ b/Sources/JSONWebSignature/DefaultJWSHeaderImpl+Codable.swift
@@ -65,7 +65,7 @@ extension DefaultJWSHeaderImpl: Codable {
         jwk = try container.decodeIfPresent(JWK.self, forKey: .jwk)
         keyID = try container.decodeIfPresent(String.self, forKey: .keyID)
         x509URL = try container.decodeIfPresent(String.self, forKey: .x509URL)
-        x509CertificateChain = try container.decodeIfPresent(String.self, forKey: .x509CertificateChain)
+        x509CertificateChain = try container.decodeIfPresent([String].self, forKey: .x509CertificateChain)
         x509CertificateSHA1Thumbprint = try container.decodeIfPresent(String.self, forKey: .x509CertificateSHA1Thumbprint)
         x509CertificateSHA256Thumbprint = try container.decodeIfPresent(String.self, forKey: .x509CertificateSHA256Thumbprint)
         type = try container.decodeIfPresent(String.self, forKey: .type)

--- a/Sources/JSONWebSignature/JWSRegisteredFieldsHeader.swift
+++ b/Sources/JSONWebSignature/JWSRegisteredFieldsHeader.swift
@@ -37,7 +37,7 @@ public protocol JWSRegisteredFieldsHeader: Codable {
     var x509URL: String? { get set }
 
     /// X.509 public key certificate or certificate chain.
-    var x509CertificateChain: String? { get set }
+    var x509CertificateChain: [String]? { get set }
 
     /// Base64URL-encoded SHA-1 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate.
     var x509CertificateSHA1Thumbprint: String? { get set }
@@ -65,7 +65,7 @@ public struct DefaultJWSHeaderImpl: JWSRegisteredFieldsHeader {
     public var jwkSetURL: String?
     public var jwk: JWK?
     public var x509URL: String?
-    public var x509CertificateChain: String?
+    public var x509CertificateChain: [String]?
     public var x509CertificateSHA1Thumbprint: String?
     public var x509CertificateSHA256Thumbprint: String?
     public var type: String?
@@ -92,7 +92,7 @@ public struct DefaultJWSHeaderImpl: JWSRegisteredFieldsHeader {
         jwkSetURL: String? = nil,
         jwk: JWK? = nil,
         x509URL: String? = nil,
-        x509CertificateChain: String? = nil,
+        x509CertificateChain: [String]? = nil,
         x509CertificateSHA1Thumbprint: String? = nil,
         x509CertificateSHA256Thumbprint: String? = nil,
         type: String? = nil,


### PR DESCRIPTION
Hello,

According to: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6

The "x5c" (X.509 certificate chain) Header Parameter contains the X.509 public key certificate or certificate chain corresponding to the key used to digitally sign the JWS.  The certificate or certificate chain is represented as a JSON array of certificate value strings.

We are looking into implementing [Issuer-signed JWT Verification Key Validation](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-04.html#name-issuer-signed-jwt-verificat) so this would really help us.

The existing tests pass with this change.

Thanks! 