### PR TITLE
feat(jwt): add new jwt validators api

### DIFF
--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyRepresentable/KeyRepresentable.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyRepresentable/KeyRepresentable.swift
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import CryptoKit
 @preconcurrency import CryptoSwift
 import Foundation

--- a/Sources/JSONWebAlgorithms/KeyManagement/KeyRepresentable/SecKeyExtended.swift
+++ b/Sources/JSONWebAlgorithms/KeyManagement/KeyRepresentable/SecKeyExtended.swift
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import CryptoKit
 @preconcurrency import CryptoSwift
 import Foundation

--- a/Sources/JSONWebToken/Claims/JWTClaimsBuilder.swift
+++ b/Sources/JSONWebToken/Claims/JWTClaimsBuilder.swift
@@ -107,6 +107,4 @@ extension ObjectClaim: JWTRegisteredFieldsClaims {
     public var jti: String? {
         objectClaims.first { $0.key == "jti" }?.element.getValue()
     }
-    
-    public func validateExtraClaims() throws {}
 }

--- a/Sources/JSONWebToken/JWT+Encryption.swift
+++ b/Sources/JSONWebToken/JWT+Encryption.swift
@@ -384,6 +384,37 @@ extension JWT {
         )
     }
     
+    /// Encrypts a JWT payload as a nested JWT in JWE format with distinct outer and inner JWE headers,
+    /// using a claims builder closure to construct the payload.
+    ///
+    /// This method creates a nested JWE structure by performing two layers of encryption:
+    /// 1. The inner layer encrypts the JWT claims (constructed via the provided `claims` builder)
+    ///    using the nested encryption parameters (headers, keys, and optional encryption values).
+    /// 2. The outer layer then encrypts the resulting inner JWT using its own set of headers,
+    ///    keys, and optional encryption parameters.
+    ///
+    /// This initializer supports different types for the `KeyRepresentable`. By default, types such as
+    /// `JWK`, `SecKey`, `CryptoSwift.RSA`, and CriptoKit EC Keys (including Curve25519) extend `KeyRepresentable`
+    /// and can be used as encryption keys.
+    ///
+    /// - Parameters:
+    ///   - claims: A closure marked with `@JWTClaimsBuilder` that constructs and returns the JWT claims to encrypt.
+    ///   - protectedHeader: A header with fields that will be protected (encrypted) in the outer JWE layer.
+    ///   - unprotectedHeader: An optional header with fields that will be unprotected (not encrypted) in the outer JWE layer.
+    ///   - senderKey: An optional `KeyRepresentable` representing the sender's key for the outer JWE layer.
+    ///   - recipientKey: An optional `KeyRepresentable` representing the recipient's key for the outer JWE layer.
+    ///   - cek: An optional content encryption key for the outer JWE layer.
+    ///   - initializationVector: An optional initialization vector for the outer JWE encryption algorithm.
+    ///   - additionalAuthenticationData: Optional additional data authenticated along with the payload for the outer JWE layer.
+    ///   - nestedProtectedHeader: A header with fields that will be protected (encrypted) in the inner JWE layer.
+    ///   - nestedUnprotectedHeader: An optional header with fields that will be unprotected (not encrypted) in the inner JWE layer.
+    ///   - nestedSenderKey: An optional `KeyRepresentable` representing the sender's key for the inner JWE layer.
+    ///   - nestedRecipientKey: An optional `KeyRepresentable` representing the recipient's key for the inner JWE layer.
+    ///   - nestedCek: An optional content encryption key for the inner JWE layer.
+    ///   - nestedInitializationVector: An optional initialization vector for the inner JWE encryption algorithm.
+    ///   - nestedAdditionalAuthenticationData: Optional additional data authenticated along with the payload for the inner JWE layer.
+    /// - Returns: A `JWT` instance representing the doubly encrypted nested JWT.
+    /// - Throws: An error if either the inner or outer encryption process fails.
     public static func encryptAsNested<
         P: JWERegisteredFieldsHeader,
         U: JWERegisteredFieldsHeader,

--- a/Sources/JSONWebToken/JWT+Error.swift
+++ b/Sources/JSONWebToken/JWT+Error.swift
@@ -35,6 +35,9 @@ extension JWT {
 
         /// Error indicating a mismatch between the expected issuer (`iss` claim) and the actual issuer of the JWT.
         case issuerMismatch
+        
+        /// Error indicating a mismatch between the expected subject (`sub` claim) and the actual subject of the JWT.
+        case subjectMismatch
 
         /// Error indicating that the JWT has expired (`exp` claim) and is no longer valid.
         case expired
@@ -48,10 +51,16 @@ extension JWT {
         /// Error indicating a mismatch between the expected audience (`aud` claim) and the actual audience of the JWT.
         case audienceMismatch
         
-        // Error indicating that JWT formats supported are JWS strings and JWE strings
+        /// Error indicating that JWT formats supported are JWS strings and JWE strings
         case unsupportedFormat
         
-        // Error indicating that JWT of JWE format cannot retrieve payload without decryption
+        /// Error indicating that JWT of JWE format cannot retrieve payload without decryption
         case cannotRetrievePayloadFromJWE
+        
+        /// Error indicating that the JWT is missing a claim required by a validator
+        case requiredClaimMissing(String)
+        
+        /// Error that is a collection of all the issues with the validation of a JWT claims
+        case multipleValidatingErrors([Error])
     }
 }

--- a/Sources/JSONWebToken/JWT+Verification.swift
+++ b/Sources/JSONWebToken/JWT+Verification.swift
@@ -22,6 +22,62 @@ import JSONWebSignature
 
 extension JWT {
     
+    /// An enumeration of validators for various JWT claims.
+    ///
+    /// Each case represents a specific validator used during JWT verification. Custom validators
+    /// conforming to `ClaimValidator` can also be provided using the `.custom` case.
+    public enum Validator {
+        /// Validates the 'iss' (issuer) claim.
+        case iss(expectedIssuer: String, required: Bool = true)
+        /// Validates the 'sub' (subject) claim.
+        case sub(expectedSubject: String, required: Bool = true)
+        /// Validates the 'aud' (audience) claim.
+        case aud(expectedAudience: [String], required: Bool = true)
+        /// Validates the 'exp' (expiration time) claim.
+        case exp(required: Bool = true)
+        /// Validates the 'nbf' (not before) claim.
+        case nbf(required: Bool = true)
+        /// Validates the 'iat' (issued at) claim.
+        case iat(required: Bool = true)
+        /// Uses a custom validator conforming to `ClaimValidator`.
+        case custom(ClaimValidator)
+        
+        /// A Boolean value indicating whether the validator is marked as required.
+        var isRequired: Bool {
+            switch self {
+            case .iss(expectedIssuer: _, required: let required),
+                 .sub(expectedSubject: _, required: let required),
+                 .aud(expectedAudience: _, required: let required),
+                 .exp(required: let required),
+                 .nbf(required: let required),
+                 .iat(required: let required):
+                return required
+            case .custom(let validator):
+                return validator.required
+            }
+        }
+        
+        /// Returns the concrete `ClaimValidator` associated with the enum case.
+        var validator: ClaimValidator {
+            switch self {
+            case .iss(let expectedIssuer, let required):
+                return IssuerValidator(expectedIssuer: expectedIssuer, required: required)
+            case .sub(let expectedSubject, let required):
+                return SubjectValidator(expectedSubject: expectedSubject, required: required)
+            case .aud(let expectedAudience, let required):
+                return ExpectedAudienceValidator(expectedAudience: expectedAudience, required: required)
+            case .exp(let required):
+                return ExpirationTimeValidator(required: required)
+            case .nbf(let required):
+                return NotBeforeTimeValidator(required: required)
+            case .iat(let required):
+                return IssuedAtValidator(required: required)
+            case .custom(let claimValidator):
+                return claimValidator
+            }
+        }
+    }
+    
     /// Verifies a JWT string and returns a decoded JWT if successful.
     ///
     /// This method supports both JWS (JSON Web Signature) and JWE (JSON Web Encryption) formats. It first determines the format of the JWT based on the number of components separated by dots in the JWT string. The method also handles nested JWTs, verifying each layer as needed.
@@ -35,8 +91,7 @@ extension JWT {
     ///   - senderKey: An optional `KeyRepresentable` representing the sender's key, used for verifying a JWS.
     ///   - recipientKey: An optional `KeyRepresentable` representing the recipient's key, used for decrypting a JWE.
     ///   - nestedKeys: An array of `KeyRepresentable` used for verifying nested JWTs.
-    ///   - expectedIssuer: An optional expected issuer (`iss` claim) to validate.
-    ///   - expectedAudience: An optional expected audience (`aud` claim) to validate.
+    ///   - validators: An array of `ClaimValidator` used to validate the JWT claims, if not set as default the `ExpirationTimeValidator`, `NotBeforeTimeValidator` and `IssuedAtValidator` will be used.
     /// - Returns: A `JWT` instance containing the payload and format.
     /// - Throws: `JWTError` if verification fails, the signature is invalid, claims validation fails, the JWT format is incorrect, or if nested JWT keys are missing.
     public static func verify(
@@ -44,8 +99,11 @@ extension JWT {
         senderKey: KeyRepresentable? = nil,
         recipientKey: KeyRepresentable? = nil,
         nestedKeys: [KeyRepresentable] = [],
-        expectedIssuer: String? = nil,
-        expectedAudience: String? = nil
+        validators: [Validator] = [
+            .exp(required: false),
+            .nbf(required: false),
+            .iat(required: false)
+        ]
     ) throws -> JWT {
         let components = jwtString.components(separatedBy: ".")
         switch components.count {
@@ -61,8 +119,7 @@ extension JWT {
                         senderKey: senderKey,
                         recipientKey: recipientKey,
                         nestedKeys: nestedKeys,
-                        expectedIssuer: expectedIssuer,
-                        expectedAudience: expectedAudience
+                        validators: validators
                     )
                 }
                 
@@ -71,20 +128,14 @@ extension JWT {
                     senderKey: key,
                     recipientKey: nil,
                     nestedKeys: nestedKeys,
-                    expectedIssuer: expectedIssuer,
-                    expectedAudience: expectedAudience
+                    validators: validators
                 )
             }
-            let payload = try JSONDecoder.jwt.decode(DefaultJWTClaimsImpl.self, from: jws.payload)
             
             guard try jws.verify(key: senderKey) else {
                 throw JWTError.invalidSignature
             }
-            try validateClaims(
-                claims: payload,
-                expectedIssuer: expectedIssuer,
-                expectedAudience: expectedAudience
-            )
+            try validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             return .init(payload: jws.payload, format: .jws(jws))
         case 5:
             let jwe = try JWE(compactString: jwtString)
@@ -104,8 +155,7 @@ extension JWT {
                         senderKey: senderKey,
                         recipientKey: recipientKey,
                         nestedKeys: nestedKeys,
-                        expectedIssuer: expectedIssuer,
-                        expectedAudience: expectedAudience
+                        validators: validators
                     )
                 }
                 
@@ -114,22 +164,17 @@ extension JWT {
                     senderKey: senderKey,
                     recipientKey: key,
                     nestedKeys: nestedKeys,
-                    expectedIssuer: expectedIssuer,
-                    expectedAudience: expectedAudience
+                    validators: validators
                 )
             }
-            let payload = try JSONDecoder.jwt.decode(DefaultJWTClaimsImpl.self, from: decryptedPayload)
-            try validateClaims(
-                claims: payload,
-                expectedIssuer: expectedIssuer,
-                expectedAudience: expectedAudience
-            )
+            try validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             
             return .init(payload: decryptedPayload, format: .jwe(jwe))
         default:
             throw JWTError.somethingWentWrong
         }
     }
+    
     /// Verifies a JSON Web Token (JWT) string by checking its signature and claims.
     ///
     /// This method supports different types for the `KeyRepresentable`.
@@ -142,8 +187,7 @@ extension JWT {
     ///   - senderKey: The cryptographic key used for verifying the JWS, which can be of type `KeyRepresentable`.
     ///   - recipientKey: The cryptographic key used for verifying the JWS, which can be of type `KeyRepresentable`.
     ///   - nestedKeys: An array of `KeyRepresentable` used for verifying nested JWTs, if applicable.
-    ///   - expectedIssuer: The expected issuer (`iss`) claim in the JWT payload.
-    ///   - expectedAudience: The expected audience (`aud`) claim in the JWT payload.
+    ///   - validators: An array of `ClaimValidator` used to validate the JWT claims, if not set as default the `ExpirationTimeValidator`, `NotBeforeTimeValidator` and `IssuedAtValidator` will be used.
     ///
     /// - Throws: An error if the verification process fails.
     /// - Returns: A `JWT` instance representing the verified JWT.
@@ -153,8 +197,11 @@ extension JWT {
         senderKey: KeyRepresentable? = nil,
         recipientKey: KeyRepresentable? = nil,
         nestedKeys: [KeyRepresentable] = [],
-        expectedIssuer: String? = nil,
-        expectedAudience: String? = nil
+        validators: [Validator] = [
+            .exp(required: false),
+            .nbf(required: false),
+            .iat(required: false)
+        ]
     ) throws -> JWT {
         let components = jwtString.components(separatedBy: ".")
         switch components.count {
@@ -170,8 +217,7 @@ extension JWT {
                         senderKey: senderKey,
                         recipientKey: recipientKey,
                         nestedKeys: nestedKeys,
-                        expectedIssuer: expectedIssuer,
-                        expectedAudience: expectedAudience
+                        validators: validators
                     )
                 }
                 
@@ -180,20 +226,14 @@ extension JWT {
                     senderKey: key,
                     recipientKey: nil,
                     nestedKeys: nestedKeys,
-                    expectedIssuer: expectedIssuer,
-                    expectedAudience: expectedAudience
+                    validators: validators
                 )
             }
-            let payload = try JSONDecoder.jwt.decode(DefaultJWTClaimsImpl.self, from: jws.payload)
             
             guard try jws.verify(key: signerKey) else {
                 throw JWTError.invalidSignature
             }
-            try validateClaims(
-                claims: payload,
-                expectedIssuer: expectedIssuer,
-                expectedAudience: expectedAudience
-            )
+            try validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             return .init(payload: jws.payload, format: .jws(jws))
         case 5:
             let jwe = try JWE(compactString: jwtString)
@@ -213,8 +253,7 @@ extension JWT {
                         senderKey: senderKey,
                         recipientKey: recipientKey,
                         nestedKeys: nestedKeys,
-                        expectedIssuer: expectedIssuer,
-                        expectedAudience: expectedAudience
+                        validators: validators
                     )
                 }
                 
@@ -223,16 +262,10 @@ extension JWT {
                     senderKey: senderKey,
                     recipientKey: key,
                     nestedKeys: nestedKeys,
-                    expectedIssuer: expectedIssuer,
-                    expectedAudience: expectedAudience
+                    validators: validators
                 )
             }
-            let payload = try JSONDecoder.jwt.decode(DefaultJWTClaimsImpl.self, from: decryptedPayload)
-            try validateClaims(
-                claims: payload,
-                expectedIssuer: expectedIssuer,
-                expectedAudience: expectedAudience
-            )
+            try validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             
             return .init(payload: decryptedPayload, format: .jwe(jwe))
         default:
@@ -240,13 +273,38 @@ extension JWT {
         }
     }
     
+    /// Validates the claims of this JWT instance using the provided validators.
+    ///
+    /// This method applies each validator from the given array to the JWT's claims. It delegates the actual
+    /// validation to the static method, which maps each `Validator` enum case to its corresponding `ClaimValidator`
+    /// implementation before performing the validations.
+    ///
+    /// - Parameter validators: An array of `Validator` used to validate specific claims within the JWT.
+    /// - Throws: A `JWT.JWTError` if any of the validations fail, such as when a required claim is missing or invalid.
+    public func validateClaims(validators: [Validator]) throws {
+        try Self.validateClaims(self.jwtString, validators: validators)
+    }
+
+    /// Validates the claims of a JWT string using the provided validators.
+    ///
+    /// This static method takes a JWT string and an array of `Validator` instances. It maps each validator to its
+    /// concrete `ClaimValidator` implementation and then passes them to an internal validation cluster function.
+    /// If any validator fails, the method throws the corresponding `JWT.JWTError`.
+    ///
+    /// - Parameters:
+    ///   - jwtString: The JWT string whose claims are to be validated.
+    ///   - validators: An array of `Validator` used to validate specific claims within the JWT.
+    /// - Throws: A `JWT.JWTError` if any of the claim validations fail.
+    public static func validateClaims(_ jwtString: String, validators: [Validator]) throws {
+        try validateClaimsCluster(jwtString, validators: validators.map(\.validator))
+    }
+    
     private static func verifyNestedWithMultipleKeys(
         jwtString: String,
         senderKey: KeyRepresentable?,
         recipientKey: KeyRepresentable?,
         nestedKeys: [KeyRepresentable],
-        expectedIssuer: String?,
-        expectedAudience: String?
+        validators: [Validator]
     ) throws -> JWT {
         for key in nestedKeys {
             do {
@@ -257,8 +315,7 @@ extension JWT {
                         senderKey: key,
                         recipientKey: recipientKey,
                         nestedKeys: nestedKeys,
-                        expectedIssuer: expectedIssuer,
-                        expectedAudience: expectedAudience
+                        validators: validators
                     )
                 case .jwe:
                     return try verify(
@@ -266,8 +323,7 @@ extension JWT {
                         senderKey: senderKey,
                         recipientKey: key,
                         nestedKeys: nestedKeys,
-                        expectedIssuer: expectedIssuer,
-                        expectedAudience: expectedAudience
+                        validators: validators
                     )
                 }
                 
@@ -279,49 +335,22 @@ extension JWT {
     }
 }
 
-public func validateClaims(
-    claims: JWTRegisteredFieldsClaims,
-    expectedIssuer: String? = nil,
-    expectedAudience: String? = nil
-) throws {
-    let currentDate = Date()
-
-    // Validate Issuer
-    if let expectedIssuer = expectedIssuer, let issuer = claims.iss {
-        guard issuer == expectedIssuer else {
-            throw JWT.JWTError.issuerMismatch
-        }
-    }
-
-    // Validate Expiration Time
-    if let expirationTime = claims.exp {
-        guard currentDate < expirationTime else {
-            throw JWT.JWTError.expired
-        }
-    }
-
-    // Validate Not Before Time
-    if let notBeforeTime = claims.nbf {
-        guard currentDate >= notBeforeTime else {
-            throw JWT.JWTError.notYetValid
-        }
-    }
-
-    // Validate Issued At
-    if let issuedAt = claims.iat {
-        guard issuedAt <= currentDate else {
-            throw JWT.JWTError.issuedInTheFuture
-        }
-    }
-
-    // Validate Audience
-    if let expectedAudience = expectedAudience, let audience = claims.aud {
-        guard audience.contains(expectedAudience) else {
-            throw JWT.JWTError.audienceMismatch
+private func validateClaimsCluster(_ jwtString: String, validators: [ClaimValidator]) throws {
+    var collectedErrors = [Error]()
+    validators.forEach {
+        do {
+            try $0.isValid(jwtString)
+        } catch {
+            collectedErrors.append(error)
         }
     }
     
-    try claims.validateExtraClaims()
+    if collectedErrors.isEmpty { return }
+    if collectedErrors.count == 1, let error = collectedErrors.first {
+        throw error
+    } else {
+        throw JWT.JWTError.multipleValidatingErrors(collectedErrors)
+    }
 }
 
 private func getKeyForJWSHeader(keys: [JWK], header: JWSRegisteredFieldsHeader?) -> JWK? {

--- a/Sources/JSONWebToken/JWTRegisteredFieldsClaims.swift
+++ b/Sources/JSONWebToken/JWTRegisteredFieldsClaims.swift
@@ -33,10 +33,6 @@ public protocol JWTRegisteredFieldsClaims {
     var iat: Date? { get }
     // "jti" claim representing a unique identifier for the JWT.
     var jti: String? { get }
-
-    /// Validates extra claims in the JWT.
-    /// - Throws: `JWTError` if any claim validations fail.
-    func validateExtraClaims() throws
 }
 
 /// `DefaultJWTClaimsImpl` is a struct implementing the `JWTRegisteredFieldsClaims` protocol, providing a default set of claims.
@@ -67,6 +63,4 @@ public struct DefaultJWTClaimsImpl: JWTRegisteredFieldsClaims, Codable {
         self.iat = iat
         self.jti = jti
     }
-    
-    public func validateExtraClaims() throws {}
 }

--- a/Sources/JSONWebToken/Validators/ClaimValidator.swift
+++ b/Sources/JSONWebToken/Validators/ClaimValidator.swift
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// A protocol for validating a specific claim within a JWT.
+/// Conforming types implement logic to verify that a claim in the provided JWT string meets expected criteria.
+public protocol ClaimValidator {
+    /// Indicates whether the claim is required.
+    var required: Bool { get }
+    
+    /// Validates the claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string containing the claim to be validated.
+    /// - Throws: An error if the claim is missing (when required) or does not meet the validation criteria.
+    func isValid(_ jwtString: String) throws
+}

--- a/Sources/JSONWebToken/Validators/ExpectedAudienceValidator.swift
+++ b/Sources/JSONWebToken/Validators/ExpectedAudienceValidator.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// A validator that checks the 'aud' (audience) claim in a JWT.
+///
+/// This validator verifies that the JWT's audience claim contains the expected audience(s).
+/// If the audience claim is missing and marked as required, a `JWT.JWTError.requiredClaimMissing("iss")` error is thrown.
+/// If the JWT's audience does not include the expected audience(s), a `JWT.JWTError.audienceMismatch` error is thrown.
+public struct ExpectedAudienceValidator: ClaimValidator, Sendable {
+    /// Indicates whether the audience claim is required.
+    public let required: Bool
+    /// The expected audience values.
+    let expectedAudience: [String]
+
+    /// Creates an audience validator with an array of expected audience values.
+    ///
+    /// - Parameters:
+    ///   - expectedAudience: An array of expected audience values.
+    ///   - required: A Boolean value indicating whether the audience claim is required. Defaults to `true`.
+    public init(expectedAudience: [String], required: Bool = true) {
+        self.expectedAudience = expectedAudience
+        self.required = required
+    }
+    
+    /// Creates an audience validator with a single expected audience value.
+    ///
+    /// - Parameters:
+    ///   - expectedAudience: The expected audience value.
+    ///   - required: A Boolean value indicating whether the audience claim is required. Defaults to `true`.
+    public init(expectedAudience: String, required: Bool = true) {
+        self.expectedAudience = [expectedAudience]
+        self.required = required
+    }
+    
+    /// Validates the audience claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("iss")` if the claim is missing when required,
+    ///           or `JWT.JWTError.audienceMismatch` if the expected audience is not present.
+    public func isValid(_ jwtString: String) throws {
+        guard let aud = try? JWT.getAudience(jwtString: jwtString) else {
+            if required {
+                throw JWT.JWTError.requiredClaimMissing("iss")
+            }
+            return
+        }
+        guard Set(aud).isSuperset(of: expectedAudience) else {
+            throw JWT.JWTError.audienceMismatch
+        }
+    }
+}

--- a/Sources/JSONWebToken/Validators/ExpirationTimeValidator.swift
+++ b/Sources/JSONWebToken/Validators/ExpirationTimeValidator.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A validator that checks the 'exp' (expiration time) claim in a JWT.
+///
+/// This validator ensures that the JWT has not expired. If the expiration claim is missing
+/// and marked as required, a `JWT.JWTError.requiredClaimMissing("exp")` error is thrown.
+/// If the current date is later than the expiration time, a `JWT.JWTError.expired` error is thrown.
+public struct ExpirationTimeValidator: ClaimValidator, Sendable {
+    /// Indicates whether the expiration time claim is required.
+    public let required: Bool
+    
+    /// Creates an expiration time validator.
+    ///
+    /// - Parameter required: A Boolean value indicating whether the expiration claim is required. Defaults to `true`.
+    public init(required: Bool = true) {
+        self.required = required
+    }
+    
+    /// Validates the expiration time claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("exp")` if the claim is missing when required,
+    ///           or `JWT.JWTError.expired` if the JWT has expired.
+    public func isValid(_ jwtString: String) throws {
+        guard let exp = try? JWT.getExpirationTime(jwtString: jwtString) else {
+            if required {
+                throw JWT.JWTError.requiredClaimMissing("exp")
+            }
+            return
+        }
+        let currentDate = Date()
+        guard currentDate < exp else {
+            throw JWT.JWTError.expired
+        }
+    }
+}

--- a/Sources/JSONWebToken/Validators/IssuedAtValidator.swift
+++ b/Sources/JSONWebToken/Validators/IssuedAtValidator.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A validator that checks the 'iat' (issued at) claim in a JWT.
+///
+/// This validator ensures that the JWT's issued-at time is not in the future.
+/// If the issued-at claim is missing and marked as required, a `JWT.JWTError.requiredClaimMissing("iat")` error is thrown.
+/// If the issued-at time is later than the current date, a `JWT.JWTError.issuedInTheFuture` error is thrown.
+public struct IssuedAtValidator: ClaimValidator, Sendable {
+    /// Indicates whether the issued-at claim is required.
+    public let required: Bool
+    
+    /// Creates an issued-at time validator.
+    ///
+    /// - Parameter required: A Boolean value indicating whether the issued-at claim is required. Defaults to `true`.
+    public init(required: Bool = true) {
+        self.required = required
+    }
+    
+    /// Validates the issued-at claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("iat")` if the claim is missing when required,
+    ///           or `JWT.JWTError.issuedInTheFuture` if the issued-at time is in the future.
+    public func isValid(_ jwtString: String) throws {
+        guard let iat = try? JWT.getIssuedAt(jwtString: jwtString) else {
+            if required {
+                throw JWT.JWTError.requiredClaimMissing("iat")
+            }
+            return
+        }
+        let currentDate = Date()
+        guard iat <= currentDate else {
+            throw JWT.JWTError.issuedInTheFuture
+        }
+    }
+}

--- a/Sources/JSONWebToken/Validators/IssuerValidator.swift
+++ b/Sources/JSONWebToken/Validators/IssuerValidator.swift
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// A validator that checks the 'iss' (issuer) claim in a JWT.
+///
+/// This validator verifies that the JWT's issuer matches an expected value. If the issuer claim is missing
+/// and marked as required, a `JWT.JWTError.requiredClaimMissing("iss")` error is thrown.
+/// If the issuer does not match the expected value, a `JWT.JWTError.issuerMismatch` error is thrown.
+public struct IssuerValidator: ClaimValidator, Sendable {
+    /// Indicates whether the issuer claim is required.
+    public let required: Bool
+    /// The expected issuer value.
+    let expectedIssuer: String
+    
+    /// Creates an issuer validator with the expected issuer.
+    ///
+    /// - Parameters:
+    ///   - expectedIssuer: The expected issuer value.
+    ///   - required: A Boolean value indicating whether the issuer claim is required. Defaults to `true`.
+    public init(expectedIssuer: String, required: Bool = true) {
+        self.expectedIssuer = expectedIssuer
+        self.required = required
+    }
+    
+    /// Validates the issuer claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("iss")` if the claim is missing when required,
+    ///           or `JWT.JWTError.issuerMismatch` if the issuer does not match the expected value.
+    public func isValid(_ jwtString: String) throws {
+        guard let issuer = try? JWT.getIssuer(jwtString: jwtString) else {
+            if required {
+                throw JWT.JWTError.requiredClaimMissing("iss")
+            }
+            return
+        }
+        if issuer != expectedIssuer {
+            throw JWT.JWTError.issuerMismatch
+        }
+    }
+}

--- a/Sources/JSONWebToken/Validators/NotBeforeTimeValidator.swift
+++ b/Sources/JSONWebToken/Validators/NotBeforeTimeValidator.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A validator that checks the 'nbf' (not before) claim in a JWT.
+///
+/// This validator ensures that the JWT is not used before the specified not-before time.
+/// If the not-before claim is missing and marked as required, a `JWT.JWTError.requiredClaimMissing("nbf")` error is thrown.
+/// If the current date is earlier than the not-before time, a `JWT.JWTError.notYetValid` error is thrown.
+public struct NotBeforeTimeValidator: ClaimValidator, Sendable {
+    /// Indicates whether the not-before claim is required.
+    public let required: Bool
+    
+    /// Creates a not-before time validator.
+    ///
+    /// - Parameter required: A Boolean value indicating whether the not-before claim is required. Defaults to `true`.
+    public init(required: Bool = true) {
+        self.required = required
+    }
+    
+    /// Validates the not-before time claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("nbf")` if the claim is missing when required,
+    ///           or `JWT.JWTError.notYetValid` if the JWT is used before the allowed time.
+    public func isValid(_ jwtString: String) throws {
+        guard let nbf = try? JWT.getNotBeforeTime(jwtString: jwtString) else {
+            if required {
+                throw JWT.JWTError.requiredClaimMissing("nbf")
+            }
+            return
+        }
+        let currentDate = Date()
+        guard currentDate >= nbf else {
+            throw JWT.JWTError.notYetValid
+        }
+    }
+}

--- a/Sources/JSONWebToken/Validators/SubjectValidator.swift
+++ b/Sources/JSONWebToken/Validators/SubjectValidator.swift
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// A validator that checks the 'sub' (subject) claim in a JWT.
+///
+/// This validator verifies that the JWT's subject matches an expected value. If the subject claim is missing
+/// and marked as required, a `JWT.JWTError.requiredClaimMissing("sub")` error is thrown.
+/// If the subject does not match the expected value, a `JWT.JWTError.subjectMismatch` error is thrown.
+public struct SubjectValidator: ClaimValidator, Sendable {
+    /// Indicates whether the subject claim is required.
+    public let required: Bool
+    /// The expected subject value.
+    let expectedSubject: String
+    
+    /// Creates a subject validator with the expected subject.
+    ///
+    /// - Parameters:
+    ///   - expectedSubject: The expected subject value.
+    ///   - required: A Boolean value indicating whether the subject claim is required. Defaults to `true`.
+    public init(expectedSubject: String, required: Bool = true) {
+        self.expectedSubject = expectedSubject
+        self.required = required
+    }
+    
+    /// Validates the subject claim in the provided JWT string.
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("sub")` if the claim is missing when required,
+    ///           or `JWT.JWTError.subjectMismatch` if the subject does not match the expected value.
+    public func isValid(_ jwtString: String) throws {
+        guard let subject = try? JWT.getSubject(jwtString: jwtString) else {
+            if required {
+                throw JWT.JWTError.requiredClaimMissing("sub")
+            }
+            return
+        }
+        if subject != expectedSubject {
+            throw JWT.JWTError.subjectMismatch
+        }
+    }
+}

--- a/Sources/jose-swift/jose-swift.docc/Articles/JWTConcepts.md
+++ b/Sources/jose-swift/jose-swift.docc/Articles/JWTConcepts.md
@@ -143,13 +143,6 @@ struct CustomClaims: JWTRegisteredFieldsClaims, Codable {
         self.jti = jti
         self.customClaim = customClaim
     }
-    
-    func validateExtraClaims() throws {
-        // Any extra validation
-        guard customClaim == "custom-value" else {
-            throw DemoError()
-        }
-    }
 }
 
 let key = P256.Signing.PrivateKey()

--- a/Sources/jose-swift/jose-swift.docc/Articles/Tutorials/CreatingJWTs.md
+++ b/Sources/jose-swift/jose-swift.docc/Articles/Tutorials/CreatingJWTs.md
@@ -37,8 +37,6 @@ struct MyClaims: JWTRegisteredFieldsClaims, Codable {
         self.sub = sub
         self.name = name
     }
-    
-    func validateExtraClaims() throws {}
 }
 
 let _ = MyClaims(iat: Date(), sub: "1234567890", name: "John Doe")

--- a/Sources/jose-swift/jose-swift.docc/Articles/Tutorials/CustomClaims.md
+++ b/Sources/jose-swift/jose-swift.docc/Articles/Tutorials/CustomClaims.md
@@ -21,8 +21,6 @@ struct CustomClaims: Codable, JWTRegisteredFieldsClaims {
     let jti: String?
     let userId: String
     let roles: [String]
-    
-    func validateExtraClaims() throws {}
 }
 ```
 Example 8.1

--- a/Sources/jose-swift/jose-swift.docc/Articles/Tutorials/VerifyingJWTs.md
+++ b/Sources/jose-swift/jose-swift.docc/Articles/Tutorials/VerifyingJWTs.md
@@ -94,7 +94,14 @@ let expectedAudience = "your-audience"
 
 let jwk = JWK(keyType: .octetSequence, key: Data(repeating: 0, count: 32))
 // The library verifies automatically iat, nbf and exp but you can pass values for iss, sub and aud
-let jwt = try JWT.verify(jwtString: "your.jwt.here", senderKey: jwk, expectedIssuer: expectedIssuer, expectedAudience: expectedAudience)
+let jwt = try JWT.verify(
+    jwtString: "your.jwt.here", 
+    senderKey: jwk, 
+    validators: [
+        .iss(expectedIssuer: expectedIssuer, required: false),
+        .aud(expectedAudience: [expectedAudience], required: false)
+    ]
+)
 print("No errors so your JWT is verified: \(jwt.jwtString)")
 ```
 Example 6.4

--- a/Tests/ExampleTests/ExampleTests.swift
+++ b/Tests/ExampleTests/ExampleTests.swift
@@ -277,13 +277,6 @@ final class ExamplesTests: XCTestCase {
                 self.jti = jti
                 self.customClaim = customClaim
             }
-            
-            func validateExtraClaims() throws {
-                // Any extra validation
-                guard customClaim == "custom-value" else {
-                    throw DemoError()
-                }
-            }
         }
 
         let key = P256.Signing.PrivateKey()
@@ -349,8 +342,6 @@ final class ExamplesTests: XCTestCase {
                 self.sub = sub
                 self.name = name
             }
-            
-            func validateExtraClaims() throws {}
         }
 
         let _ = MyClaims(iat: Date(), sub: "1234567890", name: "John Doe")
@@ -489,7 +480,14 @@ final class ExamplesTests: XCTestCase {
 
         let jwk = JWK(keyType: .octetSequence, key: Data(repeating: 0, count: 32))
         // The library verifies automatically iat, nbf and exp but you can pass values for iss, sub and aud
-        let jwt = try JWT.verify(jwtString: "your.jwt.here", senderKey: jwk, expectedIssuer: expectedIssuer, expectedAudience: expectedAudience)
+        let jwt = try JWT.verify(
+            jwtString: "your.jwt.here",
+            senderKey: jwk,
+            validators: [
+                .iss(expectedIssuer: expectedIssuer, required: false),
+                .aud(expectedAudience: [expectedAudience], required: false)
+            ]
+        )
         print("No errors so your JWT is verified: \(jwt.jwtString)")
     }
     
@@ -582,8 +580,6 @@ final class ExamplesTests: XCTestCase {
                 self.userId = userId
                 self.roles = roles
             }
-            
-            func validateExtraClaims() throws {}
         }
         
         let customClaims = CustomClaims(

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -144,7 +144,7 @@ final class JWTTests: XCTestCase {
         XCTAssertThrowsError(try JWT.verify(
             jwtString: jwtString,
             senderKey: key,
-            expectedIssuer: "Bob"
+            validators: [.iss(expectedIssuer: "Bob", required: false)]
         ))
     }
     
@@ -168,7 +168,7 @@ final class JWTTests: XCTestCase {
         XCTAssertThrowsError(try JWT.verify(
             jwtString: jwtString,
             senderKey: key,
-            expectedAudience: "Bob"
+            validators: [.aud(expectedAudience: ["Bob"], required: false)]
         ))
     }
     

--- a/Tests/JWTTests/Mock/MockExampleClaims.swift
+++ b/Tests/JWTTests/Mock/MockExampleClaims.swift
@@ -30,6 +30,4 @@ struct MockExampleClaims: JWTRegisteredFieldsClaims, Codable {
         self.jti = jti
         self.testClaim = testClaim
     }
-    
-    func validateExtraClaims() throws {}
 }


### PR DESCRIPTION
This API will simplify validation of JWTs claims, it offers customization of validators as well as integrated validators for iss, sub, exp, nbf, iat and aud