### PR TITLE
refactor!: update for encryption module container

### DIFF
--- a/Sources/JSONWebEncryption/EncryptionModule/Encryptors/JWEEncrypter.swift
+++ b/Sources/JSONWebEncryption/EncryptionModule/Encryptors/JWEEncrypter.swift
@@ -91,8 +91,7 @@ public protocol JWEMultiEncryptor: Sendable {
         additionalAuthenticationData: Data?,
         password: Data?,
         saltLength: Int?,
-        iterationCount: Int?,
-        encryptionModule: JWEEncryptionModule
+        iterationCount: Int?
     ) throws -> [JWEParts<P, R>]
 }
 
@@ -185,8 +184,7 @@ extension JWEMultiEncryptor {
         additionalAuthenticationData: Data? = nil,
         password: Data? = nil,
         saltLength: Int? = nil,
-        iterationCount: Int? = nil,
-        encryptionModule: JWEEncryptionModule = .default
+        iterationCount: Int? = nil
     ) throws -> [JWEParts<P, DefaultJWEHeaderImpl>] {
         try self.encrypt(
             payload: payload,
@@ -201,8 +199,7 @@ extension JWEMultiEncryptor {
             additionalAuthenticationData: additionalAuthenticationData,
             password: password,
             saltLength: saltLength,
-            iterationCount: iterationCount,
-            encryptionModule: encryptionModule
+            iterationCount: iterationCount
         )
     }
 }

--- a/Sources/JSONWebEncryption/EncryptionModule/Encryptors/MultiEncryptor.swift
+++ b/Sources/JSONWebEncryption/EncryptionModule/Encryptors/MultiEncryptor.swift
@@ -34,8 +34,7 @@ struct MultiEncryptor: JWEMultiEncryptor {
         additionalAuthenticationData: Data?,
         password: Data?,
         saltLength: Int?,
-        iterationCount: Int?,
-        encryptionModule: JWEEncryptionModule = .default
+        iterationCount: Int?
     ) throws -> [JWEParts<P, R>] {
         guard !recipients.isEmpty else {
             throw JWE.JWEError.noRecipients
@@ -60,22 +59,26 @@ struct MultiEncryptor: JWEMultiEncryptor {
             throw JWE.JWEError.missingKeyAlgorithm
         }
         
-        let firstEncryption = try encryptionModule.encryptor(alg: alg).encrypt(
-            payload: payload,
-            senderKey: senderKey,
-            recipientKey: firstRecipient.key,
-            protectedHeader: protectedHeader,
-            unprotectedHeader: unprotectedHeader,
-            recipientHeader: firstRecipient.header ?? R.init(from: firstRecipient.key),
-            cek: cek,
-            initializationVector: initializationVector,
-            additionalAuthenticationData: additionalAuthenticationData,
-            password: password,
-            saltLength: saltLength,
-            iterationCount: iterationCount,
-            ephemeralKey: nil,
-            hasMultiRecipients: true
-        )
+        let firstEncryption = try JWE
+            .encryptionModuleContainer
+            .encryptionModule
+            .encryptor(alg: alg)
+            .encrypt(
+                payload: payload,
+                senderKey: senderKey,
+                recipientKey: firstRecipient.key,
+                protectedHeader: protectedHeader,
+                unprotectedHeader: unprotectedHeader,
+                recipientHeader: firstRecipient.header ?? R.init(from: firstRecipient.key),
+                cek: cek,
+                initializationVector: initializationVector,
+                additionalAuthenticationData: additionalAuthenticationData,
+                password: password,
+                saltLength: saltLength,
+                iterationCount: iterationCount,
+                ephemeralKey: nil,
+                hasMultiRecipients: true
+            )
         
         return try [firstEncryption] + recipients.map { recipientHeader, key in
             guard let alg = getKeyAlgorithm(
@@ -86,22 +89,26 @@ struct MultiEncryptor: JWEMultiEncryptor {
                 throw JWE.JWEError.missingKeyAlgorithm
             }
             
-            return try encryptionModule.encryptor(alg: alg).encrypt(
-                payload: payload,
-                senderKey: senderKey,
-                recipientKey: key,
-                protectedHeader: firstEncryption.protectedHeader,
-                unprotectedHeader: unprotectedHeader,
-                recipientHeader: recipientHeader ?? R.init(from: key),
-                cek: cek,
-                initializationVector: initializationVector,
-                additionalAuthenticationData: additionalAuthenticationData,
-                password: password,
-                saltLength: saltLength,
-                iterationCount: iterationCount,
-                ephemeralKey: firstEncryption.ephemeralKey,
-                hasMultiRecipients: true
-            )
+            return try JWE
+                .encryptionModuleContainer
+                .encryptionModule
+                .encryptor(alg: alg)
+                .encrypt(
+                    payload: payload,
+                    senderKey: senderKey,
+                    recipientKey: key,
+                    protectedHeader: firstEncryption.protectedHeader,
+                    unprotectedHeader: unprotectedHeader,
+                    recipientHeader: recipientHeader ?? R.init(from: key),
+                    cek: cek,
+                    initializationVector: initializationVector,
+                    additionalAuthenticationData: additionalAuthenticationData,
+                    password: password,
+                    saltLength: saltLength,
+                    iterationCount: iterationCount,
+                    ephemeralKey: firstEncryption.ephemeralKey,
+                    hasMultiRecipients: true
+                )
         }
     }
 }

--- a/Sources/JSONWebEncryption/EncryptionModule/JWE+EncryptionModule.swift
+++ b/Sources/JSONWebEncryption/EncryptionModule/JWE+EncryptionModule.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+public final class JWEEncryptionModuleContainer: @unchecked Sendable {
+    var encryptionModule: JWEEncryptionModule
+    
+    public init(encryptionModule: JWEEncryptionModule) {
+        self.encryptionModule = encryptionModule
+    }
+    
+    public func setEncryptionModule(_ encryptionModule: JWEEncryptionModule) {
+        self.encryptionModule = encryptionModule
+    }
+}
+
 extension JWE {
-    public static let encryptionModule: JWEEncryptionModule = .default
+    public static let encryptionModuleContainer: JWEEncryptionModuleContainer = .init(encryptionModule: .default)
 }

--- a/Sources/JSONWebEncryption/JWE+Decrypt.swift
+++ b/Sources/JSONWebEncryption/JWE+Decrypt.swift
@@ -71,18 +71,21 @@ extension JWE {
             throw JWEError.missingKeyAlgorithm
         }
         
-        return try JWE.encryptionModule.decryptor(alg: alg).decrypt(
-            encodedProtectedHeader: protectedHeaderData,
-            encodedUnprotectedHeaderData: unprotectedHeaderData,
-            cipher: cipher,
-            encryptedKey: encryptedKey,
-            initializationVector: initializationVector,
-            authenticationTag: authenticationTag,
-            additionalAuthenticationData: additionalAuthenticatedData,
-            senderKey: senderKey.map { try prepareJWK(key: $0) },
-            recipientKey: recipientKey.map { try prepareJWK(key: $0) },
-            password: password
-        )
+        return try JWE
+            .encryptionModuleContainer
+            .encryptionModule
+            .decryptor(alg: alg).decrypt(
+                encodedProtectedHeader: protectedHeaderData,
+                encodedUnprotectedHeaderData: unprotectedHeaderData,
+                cipher: cipher,
+                encryptedKey: encryptedKey,
+                initializationVector: initializationVector,
+                authenticationTag: authenticationTag,
+                additionalAuthenticationData: additionalAuthenticatedData,
+                senderKey: senderKey.map { try prepareJWK(key: $0) },
+                recipientKey: recipientKey.map { try prepareJWK(key: $0) },
+                password: password
+            )
     }
     
     /// Static method to decrypt a JWE from a compact serialization string.
@@ -179,7 +182,7 @@ extension JWE {
             aad: jweJson.addtionalAuthenticatedData
         )
         
-        return try encryptionModule.multiDecryptor.decrypt(
+        return try encryptionModuleContainer.encryptionModule.multiDecryptor.decrypt(
             encodedProtectedHeader: jweJson.protectedData,
             encodedUnprotectedHeaderData: jweJson.sharedProtectedData,
             cipher: jweJson.cipherText,

--- a/Sources/JSONWebEncryption/JWE+Encrypt.swift
+++ b/Sources/JSONWebEncryption/JWE+Encrypt.swift
@@ -62,18 +62,22 @@ extension JWE {
             compressionAlgorithm: compressionAlgorithm
         )
         
-        let parts = try JWE.encryptionModule.encryptor(alg: keyManagementAlg).encrypt(
-            payload: payload,
-            senderKey: senderKey.map { try prepareJWK(key: $0) },
-            recipientKey: recipientKey.map { try prepareJWK(key: $0) },
-            protectedHeader: protectedHeader,
-            cek: cek,
-            initializationVector: initializationVector,
-            additionalAuthenticationData: additionalAuthenticationData,
-            password: password,
-            saltLength: saltLength,
-            iterationCount: iterationCount
-        )
+        let parts = try JWE
+            .encryptionModuleContainer
+            .encryptionModule
+            .encryptor(alg: keyManagementAlg)
+            .encrypt(
+                payload: payload,
+                senderKey: senderKey.map { try prepareJWK(key: $0) },
+                recipientKey: recipientKey.map { try prepareJWK(key: $0) },
+                protectedHeader: protectedHeader,
+                cek: cek,
+                initializationVector: initializationVector,
+                additionalAuthenticationData: additionalAuthenticationData,
+                password: password,
+                saltLength: saltLength,
+                iterationCount: iterationCount
+            )
         let finalProtectedHeader = parts.protectedHeader ?? protectedHeader
         self.protectedHeader = finalProtectedHeader
         self.protectedHeaderData = try JSONEncoder.jose.encode(finalProtectedHeader)
@@ -130,19 +134,23 @@ extension JWE {
             throw JWE.JWEError.missingKeyAlgorithm
         }
         
-        let parts = try JWE.encryptionModule.encryptor(alg: alg).encrypt(
-            payload: payload,
-            senderKey: senderKey.map { try prepareJWK(key: $0) },
-            recipientKey: recipientKey.map { try prepareJWK(key: $0) },
-            protectedHeader: protectedHeader,
-            unprotectedHeader: unprotectedHeader,
-            cek: cek,
-            initializationVector: initializationVector,
-            additionalAuthenticationData: additionalAuthenticationData,
-            password: password,
-            saltLength: saltLength,
-            iterationCount: iterationCount
-        )
+        let parts = try JWE
+            .encryptionModuleContainer
+            .encryptionModule
+            .encryptor(alg: alg)
+            .encrypt(
+                payload: payload,
+                senderKey: senderKey.map { try prepareJWK(key: $0) },
+                recipientKey: recipientKey.map { try prepareJWK(key: $0) },
+                protectedHeader: protectedHeader,
+                unprotectedHeader: unprotectedHeader,
+                cek: cek,
+                initializationVector: initializationVector,
+                additionalAuthenticationData: additionalAuthenticationData,
+                password: password,
+                saltLength: saltLength,
+                iterationCount: iterationCount
+            )
         
         let finalProtectedHeader = parts.protectedHeader.map { P.init(from: $0) }
         ?? protectedHeader
@@ -255,7 +263,7 @@ extension JWE {
         saltLength: Int? = nil,
         iterationCount: Int? = nil
     ) throws -> JWEJson<P, U, R> {
-        let recipientParts = try encryptionModule.multiEncryptor.encrypt(
+        let recipientParts = try encryptionModuleContainer.encryptionModule.multiEncryptor.encrypt(
             payload: payload,
             senderKey: senderKey.map { try prepareJWK(key: $0) },
             recipients: try recipients.map { ($0.header, try prepareJWK(key: $0.key)) },
@@ -266,8 +274,7 @@ extension JWE {
             additionalAuthenticationData: additionalAuthenticationData,
             password: password,
             saltLength: saltLength,
-            iterationCount: iterationCount,
-            encryptionModule: encryptionModule
+            iterationCount: iterationCount
         )
         
         guard let firstRecipient = recipientParts.first else {

--- a/Sources/JSONWebToken/Validators/X5CValidator.swift
+++ b/Sources/JSONWebToken/Validators/X5CValidator.swift
@@ -190,7 +190,7 @@ public struct X5CValidator<Policy: VerifierPolicy>: ClaimValidator, Sendable {
 private func verifyChain(
     trustedStore: CertificateStore,
     certificates: [Certificate],
-    policy: () throws -> some VerifierPolicy
+    policy: @escaping @Sendable () throws -> some VerifierPolicy
 ) async throws -> VerificationResult {
     let untrustedChain = CertificateStore(certificates)
     var verifier = try Verifier(rootCertificates: trustedStore, policy: policy)


### PR DESCRIPTION
To make sure its easy to select and diffuse a encryption module, so it works on swift 6 we now have a container