### PR TITLE
Change library type to dynamic in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     products: [
         .library(
             name: "jose-swift",
+            type: .dynamic,
             targets: [
                 "JSONWebKey",
                 "JSONWebAlgorithms",


### PR DESCRIPTION
Workaround for #57 

This should not be merged directly. Rather we'd want to update this for jose-swift to offer a Static and Dynamic variant of the library.