### PR TITLE
fix: JWT Signature Verification Bypass via None Algorithm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,11 @@ jobs:
     - name: Build
       run: swift test
   build_android:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Run unit tests
-      uses: skiptools/swift-android-action@main
+      uses: skiptools/swift-android-action@v2
       with:
-        swift-version: 6.1
-        ndk-version: 27.3.13750724
+        swift-version: 6.2

--- a/Sources/JSONWebSignature/JWS+Error.swift
+++ b/Sources/JSONWebSignature/JWS+Error.swift
@@ -55,6 +55,11 @@ extension JWS {
         /// Indicates a failure in decoding either the complete JSON or the flattened JSON structure.
         case couldNotDecodeCompleteJsonOrFlattened
         
+        /// Indicates the header is not corretly formatted
         case customHeaderIsNotCorrectlyFormatted(error: Error)
+        
+        /// Indicates a malformed JSON Web Signature that has a signature but algorithm is NONE.
+        /// This can indicate a potential attack.
+        case algorithmNoneButSignatureFound
     }
 }

--- a/Sources/JSONWebSignature/JWS+Verify.swift
+++ b/Sources/JSONWebSignature/JWS+Verify.swift
@@ -32,6 +32,9 @@ extension JWS {
     /// - Throws: An error if the verification process fails due to a missing key, unsupported algorithm, or other issues.
     /// - Returns: A Boolean value indicating whether the signature is valid (`true`) or not (`false`).
     public func verify<Key>(key: Key?) throws -> Bool {
+        if SigningAlgorithm.none == protectedHeader.algorithm, !signature.isEmpty {
+            throw JWSError.algorithmNoneButSignatureFound
+        }
         guard SigningAlgorithm.none != protectedHeader.algorithm else {
             return true
         }

--- a/Sources/JSONWebToken/JWT+Error.swift
+++ b/Sources/JSONWebToken/JWT+Error.swift
@@ -15,6 +15,7 @@
  */
 
 import Foundation
+import JSONWebAlgorithms
 
 extension JWT {
     /// `JWTError` is an enumeration representing various errors that can occur while processing JSON Web Tokens (JWTs).
@@ -74,5 +75,12 @@ extension JWT {
         
         /// Error indicating that could not validate chain
         case invalidX5Chain(errors: [String])
+        
+        /// Error indicating that the header of the JWT requires an algorithm
+        case algorithmIsRequired
+        
+        /// Error indicating the specific algorithm is black listed, by default this will be the `SigningAlgorithm.none`.
+        /// Please especify a set of validators if you dont wish this behaviour.
+        case algorithmIsBlackListed(algorithm: SigningAlgorithm)
     }
 }

--- a/Sources/JSONWebToken/JWT+Verification.swift
+++ b/Sources/JSONWebToken/JWT+Verification.swift
@@ -45,6 +45,8 @@ extension JWT {
             rootCertificates: [Certificate],
             required: Bool = true
         )
+        /// Validates if the JWT header has a algorithm set and its not `none`.
+        case blackListedAlgorithms(blackList: [SigningAlgorithm] = [.none], algorithmRequired: Bool = true)
         /// Uses a custom validator conforming to `ClaimValidator`.
         case custom(ClaimValidator)
         
@@ -57,7 +59,8 @@ extension JWT {
                  .exp(required: let required),
                  .nbf(required: let required),
                  .iat(required: let required),
-                 .x5c(rootCertificates: _, required: let required):
+                 .x5c(rootCertificates: _, required: let required),
+                 .blackListedAlgorithms(_, let required):
                 return required
             case .custom(let validator):
                 return validator.required
@@ -81,9 +84,20 @@ extension JWT {
                 return IssuedAtValidator(required: required)
             case .x5c(rootCertificates: let certificates, required: let required):
                 return X5CValidator(rootCertificates: certificates, required: required)
+            case .blackListedAlgorithms(let blackList, let required):
+                return SigningAlgorithmBlackListValidator(blackList: blackList, algorithmRequired: required)
             case .custom(let claimValidator):
                 return claimValidator
             }
+        }
+        
+        public static var defaultValidatorCluster: [Validator] {
+            [
+                .blackListedAlgorithms(algorithmRequired: true),
+                .exp(required: false),
+                .nbf(required: false),
+                .iat(required: false)
+            ]
         }
     }
     
@@ -108,11 +122,7 @@ extension JWT {
         senderKey: KeyRepresentable? = nil,
         recipientKey: KeyRepresentable? = nil,
         nestedKeys: [KeyRepresentable] = [],
-        validators: [Validator] = [
-            .exp(required: false),
-            .nbf(required: false),
-            .iat(required: false)
-        ]
+        validators: [Validator] = Validator.defaultValidatorCluster
     ) async throws -> JWT {
         let components = jwtString.components(separatedBy: ".")
         switch components.count {
@@ -140,11 +150,10 @@ extension JWT {
                     validators: validators
                 )
             }
-            
+            try await validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             guard try jws.verify(key: senderKey) else {
                 throw JWTError.invalidSignature
             }
-            try await validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             return .init(payload: jws.payload, format: .jws(jws))
         case 5:
             let jwe = try JWE(compactString: jwtString)
@@ -176,8 +185,8 @@ extension JWT {
                     validators: validators
                 )
             }
-            try await validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             
+            try await validateClaimsCluster(jwtString, validators: validators.map(\.validator))
             return .init(payload: decryptedPayload, format: .jwe(jwe))
         default:
             throw JWTError.somethingWentWrong
@@ -206,11 +215,7 @@ extension JWT {
         senderKey: KeyRepresentable? = nil,
         recipientKey: KeyRepresentable? = nil,
         nestedKeys: [KeyRepresentable] = [],
-        validators: [Validator] = [
-            .exp(required: false),
-            .nbf(required: false),
-            .iat(required: false)
-        ]
+        validators: [Validator] = Validator.defaultValidatorCluster
     ) async throws -> JWT {
         let components = jwtString.components(separatedBy: ".")
         switch components.count {

--- a/Sources/JSONWebToken/JWT.swift
+++ b/Sources/JSONWebToken/JWT.swift
@@ -18,6 +18,7 @@ import Foundation
 import JSONWebSignature
 import JSONWebEncryption
 import JSONWebKey
+import Tools
 
 /// `JWT` represents a JSON Web Token (JWT) structure as defined in [RFC7519](https://tools.ietf.org/html/rfc7519).
 public struct JWT {
@@ -78,11 +79,13 @@ public struct JWT {
 
 public extension JWT {
     /// Retrieves the payload from a JWT string and decodes it to a specified type.
-    /// - Parameter jwtString: The compact string representation of the JWT.
+    /// - Parameters:
+    ///    - jwtString: The compact string representation of the JWT.
+    ///    - decoder: JSONDecoder for the decoding, it defaults to `jwt` decoder.
     /// - Throws: An error if the decoding process fails.
     /// - Returns: The decoded payload.
-    static func getPayload<Payload: Decodable>(jwtString: String) throws -> Payload {
-        return try JSONDecoder.jwt.decode(Payload.self, from: getPayload(jwtString: jwtString))
+    static func getPayload<Payload: Decodable>(jwtString: String, decoder: JSONDecoder = .jwt) throws -> Payload {
+        return try decoder.decode(Payload.self, from: getPayload(jwtString: jwtString))
     }
     
     /// Retrieves the payload data from a JWT string.
@@ -171,6 +174,21 @@ public extension JWT {
             return jwe.protectedHeaderData
         case .jws(let jws):
             return jws.protectedHeaderData
+        }
+    }
+    
+    /// Retrieves the header as type from a JWT string.
+    /// - Parameters:
+    ///    - jwtString: The compact string representation of the JWT.
+    ///    - decoder: JSONDecoder for the decoding, it defaults to `jwt` decoder.
+    /// - Throws: An error if the decoding process fails.
+    /// - Returns: The header data.
+    static func getHeader<T: Decodable>(jwtString: String, decoder: JSONDecoder = .jwt) throws -> T {
+        switch try jwtFormat(jwtString: jwtString) {
+        case .jwe(let jwe):
+            return try decoder.decode(T.self, from: jwe.protectedHeaderData)
+        case .jws(let jws):
+            return try decoder.decode(T.self, from: jws.protectedHeaderData)
         }
     }
     

--- a/Sources/JSONWebToken/Validators/ExpectedAudienceValidator.swift
+++ b/Sources/JSONWebToken/Validators/ExpectedAudienceValidator.swift
@@ -17,7 +17,7 @@
 /// A validator that checks the 'aud' (audience) claim in a JWT.
 ///
 /// This validator verifies that the JWT's audience claim contains the expected audience(s).
-/// If the audience claim is missing and marked as required, a `JWT.JWTError.requiredClaimMissing("iss")` error is thrown.
+/// If the audience claim is missing and marked as required, a `JWT.JWTError.requiredClaimMissing("aud")` error is thrown.
 /// If the JWT's audience does not include the expected audience(s), a `JWT.JWTError.audienceMismatch` error is thrown.
 public struct ExpectedAudienceValidator: ClaimValidator, Sendable {
     /// Indicates whether the audience claim is required.
@@ -48,12 +48,12 @@ public struct ExpectedAudienceValidator: ClaimValidator, Sendable {
     /// Validates the audience claim in the provided JWT string.
     ///
     /// - Parameter jwtString: The JWT string to validate.
-    /// - Throws: `JWT.JWTError.requiredClaimMissing("iss")` if the claim is missing when required,
+    /// - Throws: `JWT.JWTError.requiredClaimMissing("aud")` if the claim is missing when required,
     ///           or `JWT.JWTError.audienceMismatch` if the expected audience is not present.
     public func isValid(_ jwtString: String) throws {
         guard let aud = try? JWT.getAudience(jwtString: jwtString) else {
             if required {
-                throw JWT.JWTError.requiredClaimMissing("iss")
+                throw JWT.JWTError.requiredClaimMissing("aud")
             }
             return
         }

--- a/Sources/JSONWebToken/Validators/SigningAlgorithmBlackListValidator.swift
+++ b/Sources/JSONWebToken/Validators/SigningAlgorithmBlackListValidator.swift
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import JSONWebAlgorithms
+import JSONWebSignature
+
+/// A validator that checks the header alg is properly set and is not one of the black listed algorithms in a JWT (only available for Signature JWTs).
+///
+/// This validator verifies that the JWT's header alg contains is set and not a black listed `SigningAlgorithm`.
+/// If the header algorithm is missing, a `JWT.JWTError.algorithmIsRequired` error is thrown.
+/// If the JWT's header algorithm is one of the black listed, a `JWT.JWTError.algorithmIsBlackListed(algorithm:)` error is thrown.
+public struct SigningAlgorithmBlackListValidator: ClaimValidator, Sendable {
+    /// Indicates whether the header requires an algorithm set.
+    public let required: Bool
+    let blackListAlgorithms: Set<SigningAlgorithm>
+
+    /// Creates an algorithm validator with an array of black listed algorithms.
+    ///
+    /// - Parameters:
+    ///    - blackList: A set of `SigningAlgorithms` that should are not permitted.
+    ///    - algorithmRequired: A Boolean value indicating whether the header requires an algorithm set. Defaults to `true`.
+    public init(blackList: [SigningAlgorithm], algorithmRequired: Bool = true) {
+        self.required = algorithmRequired
+        self.blackListAlgorithms = Set(blackList)
+    }
+    
+    /// Validates the header algorithm in the provided JWT string. (Encrypted JWTs will ignore this validator)
+    ///
+    /// - Parameter jwtString: The JWT string to validate.
+    /// - Throws: `throw JWT.JWTError.algorithmIsRequired` if the header alg is missing when required,
+    ///           or `JWT.JWTError.algorithmIsBlackListed` if the algorithm is black listed.
+    public func isValid(_ jwtString: String) throws {
+        guard case JWT.Format.jws = try JWT.jwtFormat(jwtString: jwtString) else {
+            return
+        }
+        guard
+            let header: DefaultJWSHeaderImpl = try? JWT.getHeader(jwtString: jwtString),
+            let algorithm = header.algorithm
+        else {
+            if required {
+                throw JWT.JWTError.algorithmIsRequired
+            }
+            return
+        }
+
+        guard !blackListAlgorithms.contains(algorithm) else {
+            throw JWT.JWTError.algorithmIsBlackListed(algorithm: algorithm)
+        }
+    }
+}

--- a/Tests/JWSTests/JWSTests.swift
+++ b/Tests/JWSTests/JWSTests.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import JSONWebAlgorithms
 import JSONWebKey
 @testable import JSONWebSignature
 import Tools
@@ -136,5 +137,12 @@ final class JWSTests: XCTestCase {
         let testJWS = try JWS(payload: payload.data(using: .utf8)!, key: keyPair, options: [.unencodedPayload])
         XCTAssertTrue(testJWS.compactSerialization.contains(".."))
         XCTAssertTrue(try JWS.verify(jwsString: testJWS.compactSerialization, payload: payload.data(using: .utf8)!, key: keyPair))
+    }
+    
+    func testMalformedJWSAlgNoneWithSignature() throws {
+        let header = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.none, type: "JWT")
+        let payload = #"{"sub":"user123","admin":true}"#.data(using: .utf8)!
+        let jws = try JWS(protectedHeader: header, data: payload, signature: "forgedSignature".tryToData())
+        XCTAssertThrowsError(try jws.verify(key: nil as JWK?))
     }
 }

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -11,7 +11,7 @@ final class JWTTests: XCTestCase {
         eyJhbGciOiJub25lIn0.eyJpc3MiOiJ0ZXN0QWxpY2UiLCJzdWIiOiJBbGljZSIsInRlc3RDbGFpbSI6InRlc3RlZENsYWltIn0.
         """
         
-        let jwt = try await JWT.verify(jwtString: jwtString)
+        let jwt = try await JWT.verify(jwtString: jwtString, validators: [])
         switch jwt.format {
         case .jws(let jws):
             XCTAssertEqual(jws.protectedHeader.algorithm!, .none)

--- a/Tests/JWTTests/SigningAlgorithmBlackListValidatorTests.swift
+++ b/Tests/JWTTests/SigningAlgorithmBlackListValidatorTests.swift
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Gonçalo Frade
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import JSONWebAlgorithms
+import JSONWebKey
+@testable import JSONWebToken
+import JSONWebSignature
+import JSONWebEncryption
+import XCTest
+
+final class SigningAlgorithmBlackListValidatorTests: XCTestCase {
+    
+    func testSingleAlgorithmBlackListedFailsValidation() throws {
+        let header = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.none, type: "JWT")
+        let payload = try #"{"test":"value"}"#.tryToData()
+        
+        let jwt = try JWT(payload: payload, format: .jws(.init(protectedHeader: header, data: payload, signature: Data())))
+
+        XCTAssertThrowsError(try SigningAlgorithmBlackListValidator(blackList: [.none]).isValid(jwt.jwtString))
+    }
+    
+    func testMultipleAlgorithmBlackListedFailsValidation() throws {
+        let header1 = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.none, type: "JWT")
+        let payload1 = try #"{"test":"value"}"#.tryToData()
+        
+        let header2 = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.ES256, type: "JWT")
+        let payload2 = try #"{"test":"value"}"#.tryToData()
+        
+        let jwt1 = try JWT(payload: payload1, format: .jws(.init(protectedHeader: header1, data: payload1, signature: Data())))
+        let jwt2 = try JWT(payload: payload2, format: .jws(.init(protectedHeader: header2, data: payload2, signature: Data())))
+        
+        let validator = SigningAlgorithmBlackListValidator(blackList: [.none, .ES256])
+        XCTAssertThrowsError(try validator.isValid(jwt1.jwtString))
+        XCTAssertThrowsError(try validator.isValid(jwt2.jwtString))
+    }
+    
+    func testAlgorithmNotBlackListedValidationSuccess() throws {
+        let header = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.ES256, type: "JWT")
+        let payload = try #"{"test":"value"}"#.tryToData()
+        
+        let jwt = try JWT(payload: payload, format: .jws(.init(protectedHeader: header, data: payload, signature: Data())))
+
+        XCTAssertNoThrow(try SigningAlgorithmBlackListValidator(blackList: [.none]).isValid(jwt.jwtString))
+    }
+    
+    func testMultipleAlgorithmnOTBlackListedValidationSuccess() throws {
+        let header1 = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.RS384, type: "JWT")
+        let payload1 = try #"{"test":"value"}"#.tryToData()
+        
+        let header2 = DefaultJWSHeaderImpl(algorithm: SigningAlgorithm.RS256, type: "JWT")
+        let payload2 = try #"{"test":"value"}"#.tryToData()
+        
+        let jwt1 = try JWT(payload: payload1, format: .jws(.init(protectedHeader: header1, data: payload1, signature: Data())))
+        let jwt2 = try JWT(payload: payload2, format: .jws(.init(protectedHeader: header2, data: payload2, signature: Data())))
+        
+        let validator = SigningAlgorithmBlackListValidator(blackList: [.ES256, .ES384])
+        XCTAssertNoThrow(try validator.isValid(jwt1.jwtString))
+        XCTAssertNoThrow(try validator.isValid(jwt2.jwtString))
+    }
+    
+    func testAlgorithmIsMissingFailsValidation() throws {
+        let header = DefaultJWSHeaderImpl(type: "JWT")
+        let payload = try #"{"test":"value"}"#.tryToData()
+        
+        let jwt = try JWT(payload: payload, format: .jws(.init(protectedHeader: header, data: payload, signature: Data())))
+
+        XCTAssertThrowsError(try SigningAlgorithmBlackListValidator(blackList: [.none], algorithmRequired: true).isValid(jwt.jwtString))
+    }
+    
+    func testAlgorithmIsMissingButNotRequiredValidationSuccess() throws {
+        let header = DefaultJWSHeaderImpl(type: "JWT")
+        let payload = try #"{"test":"value"}"#.tryToData()
+        
+        let jwt = try JWT(payload: payload, format: .jws(.init(protectedHeader: header, data: payload, signature: Data())))
+
+        XCTAssertNoThrow(try SigningAlgorithmBlackListValidator(blackList: [.none], algorithmRequired: false).isValid(jwt.jwtString))
+    }
+}


### PR DESCRIPTION
A security risk was identified [GHSA-88q6-jcjg-hvmw](https://github.com/beatt83/jose-swift/security/advisories/GHSA-88q6-jcjg-hvmw), it is addressed in 2 parts. First the JWS verification will now throw an error if it detects a JWS header with algorithm `none` and a signature present. Second a new validator was added to the JWT, now its possible to easily black list certain algorithms, by default `none` will be black listed, so it requires developer opt-in to remove it from the black list.



